### PR TITLE
Change protocol version to add size-based "headers" limit.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -67,8 +67,24 @@ static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
- *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
+ *  less than this number, we reached its tip. Changing this value is a protocol upgrade.
+ *
+ *  With a protocol upgrade, we now enforce an additional restriction on the
+ *  total size of a "headers" message (see below).  The absolute limit
+ *  on the number of headers still applies as well, so that we do not get
+ *  overloaded both with small and large headers.
+ */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
+/** Maximum size of a "headers" message.  This is enforced starting with
+ *  SIZE_HEADERS_LIMIT_VERSION peers and prevents overloading if we have
+ *  very large headers (due to auxpow).
+ */
+static const unsigned int MAX_HEADERS_SIZE = (6 << 20); // 6 MiB
+/** Size of a headers message that is the threshold for assuming that the
+ *  peer has more headers (even if we have less than MAX_HEADERS_RESULTS).
+ *  This is used starting with SIZE_HEADERS_LIMIT_VERSION peers.
+ */
+static const unsigned int THRESHOLD_HEADERS_SIZE = (4 << 20); // 4 MiB
 /** Size of the "block download window": how far ahead of our current height do we fetch?
  *  Larger windows tolerate larger download speed differences between peer, but increase the potential
  *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning

--- a/src/net.h
+++ b/src/net.h
@@ -49,9 +49,8 @@ static const unsigned int MAX_ADDR_TO_SEND = 1000;
  * currently acceptable).  Bitcoin has 2 MiB here, but we need more space
  * to allow for 2,000 block headers with auxpow.
  */
-/* FIXME: Possibly softfork and restrict the size of auxpows.  This would
-   allow to lower the size here with some workarounds for the historic
-   artefacts on testnet.  */
+/* FIXME: Once the headers size limit is deployed sufficiently in the network,
+   we may want to lower this again if it seems useful.  */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 32 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70011;
+static const int PROTOCOL_VERSION = 110000;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -36,5 +36,8 @@ static const int MEMPOOL_GD_VERSION = 60002;
 
 //! "filter*" commands are disabled without NODE_BLOOM after and including this version
 static const int NO_BLOOM_VERSION = 70011;
+
+//! Version when we switched to a size-based "headers" limit.
+static const int SIZE_HEADERS_LIMIT_VERSION = 110000;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
Introduce a new network-level limit on the size of "headers" messages.  In the current protocol inherited from Bitcoin, the maximum number of headers in a single message is limited to 2,000.  This number is also used to decide when to ask a peer for more.

Due to merge-mining, however, a message with 2,000 headers can be huge (and may even be too large for the P2P message limit of 32 MiB).  This patch introduces a new hard limit at 6 MiB for headers messages, used for peers advertising the new protocol version 110000.

In addition, it introduces a soft "threshold limit" of 4 MiB.  The client sends at least that many headers if it has more, so this is used as additional criterion to decide when to ask for more (if the peer has the new protocol version set).

*Please test and ACK (if you agree), but do not merge.  I'll merge via the `auxpow` branch.*

What do you think about the limits of four and six MiB?  Are they appropriate?

I've tested syncing (of the testnet headers) of "new" from "old", "old" from "new" and "new" from "new" - all work, with "new" from "new" sending headers in smaller chunks as expected.