### PR TITLE
Enable #namecoin-dev notification on travis-ci build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@
 os: linux
 language: cpp
 compiler: gcc
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#namecoin-dev"
+    on_success: never
 env:
   global:
     - MAKEJOBS=-j3


### PR DESCRIPTION
Fixes namecoin/meta#20.

Didn't actually setup Travis-CI and test this, but it should work according to the documentation.