### PR TITLE
Fix version in name of Gitian Linux descriptor (0.12)

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "namecoin-linux-0.10"
+name: "namecoin-linux-0.12"
 enable_cache: true
 suites:
 - "trusty"


### PR DESCRIPTION
This is a backport specifically for the 0.12 branch; do not merge to master.  Fixes https://github.com/namecoin/namecoin-core/issues/57