### PR TITLE
[WIP] Implement hardfork to counter BIP9

### DIFF
--- a/TODO
+++ b/TODO
@@ -3,16 +3,8 @@
 * implement proper size computation for name cache
 
 * upgrade to new version at fixed height:
-  - P2SH as enforced soft fork (BIP16)
-  - strict BIP30 as enforced soft fork
-  - allow larger blocks (DB locks)
-  - no need to disallow auxpow parent blocks with auxpow-flag in the version
-    any more; instead, the auxpow is simply never loaded for them
-  - disallow legacy blocks also on testnet
   - restrict auxpow size / coinbase tx size?
   - name_new format change?
-  - make NamecoinTxVersion a flag?
-  - more differences???
 
 * reenable some of the disabled tests, new alert keys?
 

--- a/TODO.always-auxpow
+++ b/TODO.always-auxpow
@@ -1,0 +1,5 @@
+* remove BDB lock limit in fork
+
+* enable BIP16 and BIP30 at the same time
+
+* get rid of tx Namecoin version as well?

--- a/TODO.always-auxpow
+++ b/TODO.always-auxpow
@@ -1,5 +1,1 @@
-* remove BDB lock limit in fork
-
-* enable BIP16 and BIP30 at the same time
-
-* get rid of tx Namecoin version as well?
+* get rid of tx Namecoin version as well

--- a/TODO.always-auxpow
+++ b/TODO.always-auxpow
@@ -1,1 +1,0 @@
-* get rid of tx Namecoin version as well

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -115,10 +115,12 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py',
-    'p2p-versionbits-warning.py',
+    # FIXME: Reenable and possibly fix once the BIP9 mining is activated.
+    #'p2p-versionbits-warning.py',
 
     # auxpow tests
     'getauxblock.py',
+    'always-auxpow.py',
 
     # name tests
     'name_expiration.py',

--- a/qa/rpc-tests/always-auxpow.py
+++ b/qa/rpc-tests/always-auxpow.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright (c) 2016 Daniel Kraft
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Test the always-auxpow fork transition.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from test_framework import auxpow
+
+class AlwaysAuxpowTest (BitcoinTestFramework):
+
+  def run_test (self):
+    BitcoinTestFramework.run_test (self)
+
+    # FIXME: Set final value here.
+    forktime = 1483225200
+
+    # Set mock times of nodes to be around the fork time.
+    self.nodes[0].setmocktime (forktime - 1)
+    self.nodes[1].setmocktime (forktime)
+    self.nodes[2].setmocktime (forktime)
+    self.nodes[3].setmocktime (forktime)
+
+    # Verify mining some blocks.
+    self.mineAndVerify (0, 1, False)
+    self.mineAndVerify (1, 0, True)
+    self.mineAndVerify (0, 1, False)
+
+    # Do the same with getauxblock mined blocks.
+    blkhash = auxpow.mineAuxpowBlock (self.nodes[0])
+    self.sync_all ()
+    self.verify (self.nodes[1].getblock (blkhash), False)
+    blkhash = auxpow.mineAuxpowBlock (self.nodes[1])
+    self.sync_all ()
+    self.verify (self.nodes[0].getblock (blkhash), True)
+
+    # Update mock time.
+    self.nodes[0].setmocktime (forktime + 1)
+    self.mineAndVerify (0, 1, True)
+    self.mineAndVerify (1, 0, True)
+
+    # Mine some more blocks, just to be sure.
+    for i in range (10):
+      self.nodes[0].setmocktime (forktime + 4 * i)
+      self.nodes[1].setmocktime (forktime + 4 * i + 1)
+      self.nodes[2].setmocktime (forktime + 4 * i + 2)
+      self.nodes[3].setmocktime (forktime + 4 * i + 3)
+      self.mineAndVerify (0, 1, True)
+      self.mineAndVerify (1, 2, True)
+      self.mineAndVerify (2, 3, True)
+      blkhash = auxpow.mineAuxpowBlock (self.nodes[3])
+      self.sync_all ()
+      self.verify (self.nodes[0].getblock (blkhash), True)
+
+  def mineAndVerify (self, indMine, indCheck, shouldBeForked):
+    """
+    Mine a block on node indMine and verify that it either has the
+    characteristics before or after the fork in the block.  Node indCheck
+    is used to retrieve block data afterwards.
+    """
+
+    blkhash = self.nodes[indMine].generate (1)
+    self.sync_all ()
+    assert_equal (len (blkhash), 1)
+    blkhash = blkhash[0]
+    blk = self.nodes[indCheck].getblock (blkhash)
+
+    self.verify (blk, shouldBeForked)
+
+  def verify (self, blk, shouldBeForked):
+    """
+    Verify if the given blk (as JSON data) satisfies the pre- or
+    postfork conditions.
+    """
+
+    if shouldBeForked:
+      assert blk['version'] < (1 << 8)
+      assert_equal (blk['nonce'], 1)
+    else:
+      assert blk['version'] > (1 << 16)
+      assert_equal (blk['version'] >> 16, 1)
+
+if __name__ == '__main__':
+  AlwaysAuxpowTest ().main ()

--- a/qa/rpc-tests/name_registration.py
+++ b/qa/rpc-tests/name_registration.py
@@ -186,5 +186,28 @@ class NameRegistrationTest (NameTestFramework):
     self.checkName (1, "node-1", "reregistered", 23, False)
     self.checkNameHistory (1, "node-1", ["x" * 520, "reregistered"])
 
+    # Verify name ops around the always-auxpow fork point, just to be sure.
+    # FIXME: Set final value here.
+    forktime = 1483225200
+
+    self.nodes[0].setmocktime (forktime - 1)
+    self.nodes[1].setmocktime (forktime)
+    self.nodes[2].setmocktime (forktime)
+    self.nodes[3].setmocktime (forktime)
+
+    newA = self.nodes[0].name_new ("name-1")
+    newB = self.nodes[1].name_new ("name-2")
+    self.generate (0, 15)
+    self.firstupdateName (0, "name-1", newA, "a")
+    self.firstupdateName (1, "name-2", newB, "b")
+    self.generate (1, 1)
+    self.checkName (2, "name-1", "a", None, False)
+    self.checkName (2, "name-2", "b", None, False)
+    self.nodes[0].name_update ("name-1", "aa")
+    self.nodes[1].name_update ("name-2", "bb")
+    self.generate (0, 1)
+    self.checkName (2, "name-1", "aa", None, False)
+    self.checkName (2, "name-2", "bb", None, False)
+
 if __name__ == '__main__':
   NameRegistrationTest ().main ()

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -236,6 +236,8 @@ CAuxPow::initAuxPow (CBlockHeader& header)
   /* Build a fake parent block with the coinbase.  */
   CBlock parent;
   parent.nVersion = 1;
+  //parent.nTime = header.nTime;
+  //parent.nNonce = 100;
   parent.vtx.resize (1);
   parent.vtx[0] = coinbase;
   parent.hashMerkleRoot = BlockMerkleRoot (parent);

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -101,9 +101,6 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
     if (nIndex != 0)
         return error("AuxPow is not a generate");
 
-    if (params.fStrictChainId && parentBlock.GetChainId () == nChainId)
-        return error("Aux POW parent has our chain ID");
-
     if (vChainMerkleBranch.size() > 30)
         return error("Aux POW chain merkle branch too long");
 
@@ -221,9 +218,6 @@ CAuxPow::CheckMerkleBranch (uint256 hash,
 void
 CAuxPow::initAuxPow (CBlockHeader& header)
 {
-  /* Set auxpow flag right now, since we take the block hash below.  */
-  header.SetAuxpowVersion(true);
-
   /* Build a minimal coinbase script input for merge-mining.  */
   const uint256 blockHash = header.GetHash ();
   valtype inputData(blockHash.begin (), blockHash.end ());

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -14,24 +14,25 @@ using namespace std;
 CBlockHeader CBlockIndex::GetBlockHeader(const Consensus::Params& consensusParams) const
 {
     CBlockHeader block;
-
     block.nVersion       = nVersion;
-
-    /* The CBlockIndex object's block header is missing the auxpow.
-       So if this is an auxpow block, read it from disk instead.  We only
-       have to read the actual *header*, not the full block.  */
-    if (block.IsAuxpow())
-    {
-        ReadBlockHeaderFromDisk(block, this, consensusParams);
-        return block;
-    }
-
     if (pprev)
         block.hashPrevBlock = pprev->GetBlockHash();
     block.hashMerkleRoot = hashMerkleRoot;
     block.nTime          = nTime;
     block.nBits          = nBits;
     block.nNonce         = nNonce;
+
+    /* The CBlockIndex object's block header is missing the auxpow.
+       So if this is an auxpow block, read it from disk instead.  We only
+       have to read the actual *header*, not the full block.  Note that
+       this must be after setting at least nVersion and nTime in the block
+       header above, so that IsAuxpow() actually works.  */
+    if (block.IsAuxpow())
+    {
+        ReadBlockHeaderFromDisk(block, this, consensusParams);
+        return block;
+    }
+
     return block;
 }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -272,7 +272,7 @@ public:
     /* Analyse the block version.  */
     inline int GetBaseVersion() const
     {
-        return CPureBlockHeader::GetBaseVersion(nVersion);
+        return CPureBlockHeader::GetBaseVersion(nTime, nVersion);
     }
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2360,9 +2360,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // See BIP30 and http://r6.ca/blog/20120206T005236Z.html for more information.
     // This logic is not necessary for memory pool transactions, as AcceptToMemoryPool
     // already refuses previously-known transaction ids entirely.
-    // FIXME: Enable strict check after appropriate fork.
     bool fEnforceBIP30 = (!pindex->phashBlock) || // Enforce on CreateNewBlock invocations which don't have a hash.
-                          !(true);
+                          block.AlwaysAuxpowActive();
 
     // Once BIP34 activated it was not possible to create new duplicate coinbases and thus other than starting
     // with the 2 existing duplicate coinbase pairs, not possible to create overwriting txs.  But by the
@@ -2383,9 +2382,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
 
-    // Disable strict BIP16 checks until we do a softfork for it
-    // FIXME: Enable strict check in the future.
-    const bool fStrictPayToScriptHash = false;
+    // Strict BIP16 checks were enabled together with the always-active fork.
+    const bool fStrictPayToScriptHash = block.AlwaysAuxpowActive();
 
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
@@ -3418,7 +3416,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // Enforce the temporary DB lock limit.
     // TODO: Remove with a hardfork in the future.
-    if (!CheckDbLockLimit(block))
+    if (!block.AlwaysAuxpowActive() && !CheckDbLockLimit(block))
         return state.DoS(100, error("%s : DB lock limit failed", __func__),
                          REJECT_INVALID, "bad-db-locks");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,14 @@ using namespace std;
 
 CCriticalSection cs_main;
 
+/**
+ * Temporary "second" fork time for when the auxpow parent block is allowed
+ * to take on the same chain ID.
+ * FIXME: Remove once the chain is beyond this point.
+ * FIXME: Update value, currently 2017-01-02.
+ */
+static const int32_t FORK_TIME_SAME_CHAIN_ID = 1483311600;
+
 BlockMap mapBlockIndex;
 CChain chainActive;
 CBlockIndex *pindexBestHeader = NULL;
@@ -1505,14 +1513,16 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
 {
     /* Except for legacy blocks with full version 1, ensure that
        the chain ID is correct.  Legacy blocks are not allowed since
-       the merge-mining start, which is checked in AcceptBlockHeader
+       the merge-mining start, which is checked in ContextualCheckBlockHeader
        where the height is known.  */
     if (!block.IsLegacy() && params.fStrictChainId
         && block.GetChainId() != params.nAuxpowChainId)
         return error("%s : block does not have our chain ID"
-                     " (got %d, expected %d, full nVersion %d)",
+                     " (got %d, expected %d,"
+                     " full nTime %d, nVersion %d, nNonce %d)",
                      __func__, block.GetChainId(),
-                     params.nAuxpowChainId, block.nVersion);
+                     params.nAuxpowChainId,
+                     block.nTime, block.nVersion, block.nNonce);
 
     /* If there is no auxpow, just check the block hash.  */
     if (!block.auxpow)
@@ -1520,6 +1530,11 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
         if (block.IsAuxpow())
             return error("%s : no auxpow on block with auxpow version",
                          __func__);
+
+        /* This should only ever happen before the always-auxpow fork.
+           Afterwards, IsAuxpow returns always true.  Nevertheless enforce
+           this check here just to be sure.  */
+        assert (!block.AlwaysAuxpowActive ());
 
         if (!CheckProofOfWork(block.GetHash(), block.nBits, params))
             return error("%s : non-AUX proof of work failed", __func__);
@@ -1533,10 +1548,19 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
     /* Temporary check:  Disallow parent blocks with auxpow version.  This is
-       for compatibility with the old client.  */
-    /* FIXME: Remove this check with a hardfork later on.  */
-    if (block.auxpow->getParentBlock().IsAuxpow())
+       for compatibility with the old client.  We use the old flag check
+       with nVersion instead of calling IsAuxpow(), so that this does not
+       fail if the parent block's nTime is beyond the fork point
+       but our time is not yet.  */
+    /* FIXME: Remove this check once we are beyond this point in time.  */
+    if (!block.AlwaysAuxpowActive ()
+          && (block.auxpow->getParentBlock().nVersion & CPureBlockHeader::VERSION_AUXPOW))
         return error("%s : auxpow parent block has auxpow version", __func__);
+
+    /* FIXME: Get rid of this check once we are beyond that point in time.  */
+    if (block.GetBlockTime() < FORK_TIME_SAME_CHAIN_ID && params.fStrictChainId
+          && block.auxpow->parentBlock.GetChainId () == block.GetChainId ())
+        return error("%s : Aux POW parent has our chain ID", __func__);
 
     if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
@@ -3444,6 +3468,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // Disallow legacy blocks after merge-mining start.
+    // FIXME: Get rid of this after the always-auxpow fork is active.
     const int nHeight = pindexPrev->nHeight+1;
     if (!Params().GetConsensus().AllowLegacyBlocks(nHeight) && block.IsLegacy())
         return state.DoS(100, error("%s : legacy block after auxpow start",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1375,7 +1375,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_NAMES_MEMPOOL, true))
+        if (!CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_NAMES_MEMPOOL | SCRIPT_VERIFY_STRICT_NAMECOIN_VERSION, true))
             return false; // state filled in by CheckInputs
 
         // Check again against just the consensus-critical mandatory script
@@ -1392,7 +1392,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         // not (yet) be valid in a block, namely premature NAME_FIRSTUPDATE's.
         // Thus add the mempool-flag here.
         const unsigned flags
-          = MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_NAMES_MEMPOOL;
+          = MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_NAMES_MEMPOOL | SCRIPT_VERIFY_STRICT_NAMECOIN_VERSION;
         if (!CheckInputs(tx, state, view, true, flags, true))
         {
             return error("%s: BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s, %s",
@@ -2398,6 +2398,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (block.GetBaseVersion() >= 4 && IsSuperMajority(4, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
+
+    if (!block.AlwaysAuxpowActive())
+        flags |= SCRIPT_VERIFY_STRICT_NAMECOIN_VERSION;
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -56,7 +56,7 @@ public:
     }
 };
 
-int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
+int64_t UpdateTime(CBlockHeader* pblock, const int32_t nVersion, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
@@ -67,6 +67,10 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     // Updating time can change work required on testnet:
     if (consensusParams.AllowMinDifficultyBlocks(pblock->GetBlockTime()))
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+
+    // Set the block's version.  This is influenced by the time, since
+    // the time triggers the always-auxpow fork.
+    pblock->SetVersionAndChainId (nVersion, consensusParams.nAuxpowChainId);
 
     return nNewTime - nOldTime;
 }
@@ -123,6 +127,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     uint64_t nBlockTx = 0;
     unsigned int nBlockSigOps = 100;
     int lastFewTxs = 0;
+    int32_t nVersion;
     CAmount nFees = 0;
 
     {
@@ -132,15 +137,14 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         pblock->nTime = GetAdjustedTime();
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
 
-        const int32_t nChainId = chainparams.GetConsensus ().nAuxpowChainId;
+        //const int32_t nChainId = chainparams.GetConsensus ().nAuxpowChainId;
         // FIXME: Active version bits after the always-auxpow fork!
-        //const int32_t nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
-        const int32_t nVersion = 4;
-        pblock->SetBaseVersion(nVersion, nChainId);
+        //nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
+        nVersion = 4;
         // -regtest only: allow overriding block.nVersion with
         // -blockversion=N to test forking scenarios
         if (chainparams.MineBlocksOnDemand())
-            pblock->SetBaseVersion(GetArg("-blockversion", pblock->GetBaseVersion()), nChainId);
+            nVersion = GetArg("-blockversion", nVersion);
 
         int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
                                 ? nMedianTimePast
@@ -328,9 +332,10 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
+        UpdateTime(pblock, nVersion, chainparams.GetConsensus(), pindexPrev);
         pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
-        pblock->nNonce         = 0;
+        if (!pblock->AlwaysAuxpowActive())
+            pblock->nNonce = 0;
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
         CValidationState state;

--- a/src/miner.h
+++ b/src/miner.h
@@ -30,7 +30,7 @@ struct CBlockTemplate
 CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
-int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
+int64_t UpdateTime(CBlockHeader* pblock, const int32_t nVersion, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 bool ProcessBlockFound(const CBlock* pblock, const CChainParams& chainParams);
 
 #endif // BITCOIN_MINER_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -10,19 +10,6 @@
 #include "utilstrencodings.h"
 #include "crypto/common.h"
 
-void CBlockHeader::SetAuxpow (CAuxPow* apow)
-{
-    if (apow)
-    {
-        auxpow.reset(apow);
-        SetAuxpowVersion(true);
-    } else
-    {
-        auxpow.reset();
-        SetAuxpowVersion(false);
-    }
-}
-
 std::string CBlock::ToString() const
 {
     std::stringstream s;

--- a/src/primitives/pureheader.cpp
+++ b/src/primitives/pureheader.cpp
@@ -13,9 +13,19 @@ uint256 CPureBlockHeader::GetHash() const
     return SerializeHash(*this);
 }
 
-void CPureBlockHeader::SetBaseVersion(int32_t nBaseVersion, int32_t nChainId)
+void CPureBlockHeader::SetVersionAndChainId(int32_t ver, int32_t chainId)
 {
-    assert(nBaseVersion >= 1 && nBaseVersion < VERSION_AUXPOW);
-    assert(!IsAuxpow());
-    nVersion = nBaseVersion | (nChainId * VERSION_CHAIN_START);
+  if (!AlwaysAuxpowActive ())
+    {
+      assert (ver >= 0 && ver < VERSION_AUXPOW);
+      nVersion = ver
+                  | (chainId * VERSION_CHAIN_START)
+                  | VERSION_AUXPOW;
+    }
+  else
+    {
+      assert (chainId >= 0 && chainId <= NONCE_CHAINID_MASK);
+      nVersion = ver;
+      nNonce = chainId;
+    }
 }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -264,6 +264,8 @@ public:
         return (vin.size() == 1 && vin[0].prevout.IsNull());
     }
 
+    // FIXME: Get rid of this once the fork is passed that lifts the restriction
+    // on Namecoin transactions only with NMC version.
     bool IsNamecoin() const
     {
         return nVersion == NAMECOIN_VERSION;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -844,6 +844,7 @@ UniValue getauxblock(const UniValue& params, bool fHelp)
             pblocktemplate = CreateNewBlock(Params(), coinbaseScript->reserveScript);
             if (!pblocktemplate)
                 throw JSONRPCError(RPC_OUT_OF_MEMORY, "out of memory");
+            assert(pblocktemplate->block.IsAuxpow());
 
             // Update state only when CreateNewBlock succeeded
             nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
@@ -853,7 +854,6 @@ UniValue getauxblock(const UniValue& params, bool fHelp)
             // Finalise it by setting the version and building the merkle root
             CBlock* pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
-            pblock->SetAuxpowVersion(true);
 
             // Save
             mapNewBlock[pblock->GetHash()] = pblock;

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -488,7 +488,7 @@ name_pending (const UniValue& params, bool fHelp)
        i != txHashes.end (); ++i)
     {
       CTransaction tx;
-      if (!mempool.lookup (*i, tx) || !tx.IsNamecoin ())
+      if (!mempool.lookup (*i, tx))
         continue;
 
       for (unsigned i = 0; i < tx.vout.size (); ++i)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -90,6 +90,11 @@ enum
     // Perform name checks in "mempool" mode.  This allows / disallows
     // certain stuff (e. g., it allows immature spending of name_new's).
     SCRIPT_VERIFY_NAMES_MEMPOOL = (1U << 24),
+
+    // Enforce strict NamecoinVersion tx checks.
+    // FIXME: Get rid of this once the chain is beyond the
+    // always-auxpow fork and we no longer need to enforce those.
+    SCRIPT_VERIFY_STRICT_NAMECOIN_VERSION = (1U << 25),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -60,6 +60,20 @@ struct {
     {2, 0xbbbeb305}, {2, 0xfe1c810a},
 };
 
+// Thin wrapper around CreateNewBlock that unsets the block's auxpow
+// version flag.  This is necessary for the predefined data here
+// to make sense.
+static CBlockTemplate*
+CreateNewBlock2(const CChainParams& chainparams, const CScript& scriptPubKeyIn)
+{
+  CBlockTemplate* res = CreateNewBlock (chainparams, scriptPubKeyIn);
+  res->block.nVersion &= ~CPureBlockHeader::VERSION_AUXPOW;
+  assert (!res->block.IsAuxpow ());
+  return res;
+}
+
+#define CreateNewBlock CreateNewBlock2
+
 CBlockIndex CreateBlockIndex(int nHeight)
 {
     CBlockIndex index;
@@ -389,5 +403,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = true;
 }
 #endif
+
+#undef CreateNewBlock
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/name_tests.cpp
+++ b/src/test/name_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Daniel Kraft
+// Copyright (c) 2014-2016 Daniel Kraft
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -534,27 +534,33 @@ BOOST_AUTO_TEST_CASE (name_tx_verification)
   mtx.vout.push_back (CTxOut (COIN, addr));
   const CTransaction baseTx(mtx);
 
+  const unsigned strictVersion = SCRIPT_VERIFY_STRICT_NAMECOIN_VERSION;
+
   /* Non-name tx should be non-Namecoin version.  */
+  BOOST_CHECK (CheckNameTransaction (baseTx, 200000, view, state,
+                                     strictVersion));
   BOOST_CHECK (CheckNameTransaction (baseTx, 200000, view, state, 0));
   mtx.SetNamecoin ();
-  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, 0));
+  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, strictVersion));
+  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, 0));
 
   /* Name tx should be Namecoin version.  */
   mtx = CMutableTransaction (baseTx);
-  mtx.vin.push_back (CTxIn (COutPoint (inNew, 0)));
-  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, 0));
+  mtx.vout.push_back (CTxOut (COIN, scrNew));
+  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, strictVersion));
+  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, 0));
   mtx.SetNamecoin ();
-  mtx.vin.push_back (CTxIn (COutPoint (inUpdate, 0)));
-  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, 0));
+  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, strictVersion));
+  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, 0));
 
   /* Duplicate name outs are not allowed.  */
   mtx = CMutableTransaction (baseTx);
   mtx.vout.push_back (CTxOut (COIN, scrNew));
-  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, 0));
+  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, strictVersion));
   mtx.SetNamecoin ();
-  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, 0));
+  BOOST_CHECK (CheckNameTransaction (mtx, 200000, view, state, strictVersion));
   mtx.vout.push_back (CTxOut (COIN, scrNew));
-  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, 0));
+  BOOST_CHECK (!CheckNameTransaction (mtx, 200000, view, state, strictVersion));
 
   /* ************************** */
   /* Test NAME_NEW validation.  */

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -6,6 +6,7 @@
 
 #include "test_bitcoin.h"
 
+#include "auxpow.h"
 #include "chainparams.h"
 #include "consensus/consensus.h"
 #include "consensus/validation.h"
@@ -129,8 +130,11 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
     unsigned int extraNonce = 0;
     IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+    assert (block.IsAuxpow ());
+    CAuxPow::initAuxPow(block);
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+    CPureBlockHeader& miningHeader = block.auxpow->parentBlock;
+    while (!CheckProofOfWork(miningHeader.GetHash(), block.nBits, chainparams.GetConsensus())) ++miningHeader.nNonce;
 
     CValidationState state;
     ProcessNewBlock(state, chainparams, NULL, &block, true, NULL);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -46,19 +46,14 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
     nModFeesWithAncestors = nFee;
     nSigOpCountWithAncestors = sigOpCount;
 
-    if (tx.IsNamecoin())
+    BOOST_FOREACH(const CTxOut& txout, tx.vout)
     {
-        BOOST_FOREACH(const CTxOut& txout, tx.vout)
-        {
-            const CNameScript curNameOp(txout.scriptPubKey);
-            if (!curNameOp.isNameOp())
-                continue;
+        const CNameScript curNameOp(txout.scriptPubKey);
+        if (!curNameOp.isNameOp())
+            continue;
 
-            assert(!nameOp.isNameOp());
-            nameOp = curNameOp;
-        }
-
-        assert(nameOp.isNameOp());
+        assert(!nameOp.isNameOp());
+        nameOp = curNameOp;
     }
 }
 

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -85,8 +85,6 @@ name_list (const UniValue& params, bool fHelp)
                  pwalletMain->mapWallet)
     {
       const CWalletTx& tx = item.second;
-      if (!tx.IsNamecoin ())
-        continue;
 
       CNameScript nameOp;
       int nOut = -1;


### PR DESCRIPTION
This implements a hardfork to "fix" potential future issues with Bitcoin adopting BIP9, see the discussion in https://forum.namecoin.info/viewtopic.php?f=5&t=2466.  The fork point is currently set to 2017-01-01, but should be adapted accordingly once we reach a consensus of when to schedule the fork.

DO NOT MERGE, but please review and test as much as you like.  Once everything is resolved and ACK'ed, I want to merge via `auxpow`.

See the individual commit comments for detailed information on the implemented changes, but here's a brief overview of what forking changes the PR introduces:
- Blocks after the fork time must be merge mined.  Their `nVersion` field will no longer be interpreted as auxpow-flag and chain ID and can instead be arbitrarily chosen.  The `nNonce` field holds the chain ID for those blocks.
- Parent blocks of merge-mined blocks will no longer have any restrictions as well, they can have arbitrary `nVersion`.  This lifts two existing restrictions; currently, parent blocks must not have the "auxpow-flag bit" set in `nVersion`, and they must not have the same chain ID.  The check for same chain ID will be lifted a little _after_ the fork time.
- BIP16 and BIP30 will be enabled at the fork time.
- Namecoin transactions will no longer be required to have a specific `nVersion`.  The mempool policy is not yet changed and the client still sets the Namecoin `nVersion` by default.  But these can be removed in the future without another fork.  This helps to prevent issues in case upstream Bitcoin switches to another `nVersion` for transactions as well.

I'm aware of a potential small caveat with the proposed fork:  During the "transition window" of one day after the fork where the parent block chain ID check is still enforced, parent blocks must not have a `nNonce` with the low 16 bits giving exactly 1.  Assuming that the nonce is random, this is a 1 : 65536 chance, so it should not be a big problem; it will go away as soon as the second fork time activates.
