### PR TITLE
Add missing header file

### DIFF
--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -12,6 +12,7 @@
 #include "rpc/server.h"
 #include "script/names.h"
 #include "txmempool.h"
+#include "utilstrencodings.h"
 #ifdef ENABLE_WALLET
 # include "wallet/wallet.h"
 #endif


### PR DESCRIPTION
Added a reference to utilstrencodings.h, necessary to compile the RPC for names.