### PR TITLE
Introduce an earlier check for invalid Namecoin tx

### DIFF
--- a/src/names/main.h
+++ b/src/names/main.h
@@ -238,7 +238,7 @@ public:
  * ensures that all name operations (if any) are valid and that it has
  * name operations iff it is marked as Namecoin tx by its version.
  * @param tx The transaction to check.
- * @param nHeight Height at which the tx will be.  May be MEMPOOL_HEIGHT.
+ * @param nHeight Height at which the tx will be.
  * @param view The current chain state.
  * @param state Resulting validation state.
  * @param flags Verification flags.


### PR DESCRIPTION
This fixes #116.  The crash described there happens when adding an invalid transaction to the mempool, since the constructor of `CTxMempoolEntry` assumes that we have a valid structure for name tx (at most one name input/output).  This is checked only later at the moment, failing an assertion.

This patch introduces an earlier check for the validity of a Namecoin transaction when adding to mempool, so that this assumption is actually valid later on.  The check still happens as part of `CheckInputs`, which is redundant for the mempool addition (not block verification) but that is no problem.