### PR TITLE
Set activation height of BIP65.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -98,9 +98,7 @@ public:
            and thus this is also fine.  */
         consensus.BIP34Height = 250000;
         consensus.BIP34Hash = uint256S("0x514ec75480df318ffa7eb4eff82e1c583c961aa64cce71b5922662f01ed1686a");
-        // FIXME: BIP65 is not yet active on mainnet, activate it by setting
-        // a corresponding scheduled height here.
-        consensus.BIP65Height = 1000000;
+        consensus.BIP65Height = 335000;
         consensus.BIP66Height = 250000;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks


### PR DESCRIPTION
BIP65 finally activated with `nVersion=4` on Namecoin mainnet.  Set the activation height to block 335k (at which it was already fully active).

Please check carefully and ACK if this looks good.  Then I'll merge this on `dev` and `dev-0.14`, and rename the branches accordingly.  (`dev-0.14` to `0.14`, `master` to `legacy-pre-0.14` and `dev` to `master`, unless someone has better suggestions.)