### PR TITLE
[Mining] add rpc commands: “createauxblock” and “submitauxblock”

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -870,15 +870,17 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
 /* ************************************************************************** */
 /* Merge mining.  */
 
-/* The variables below are used to keep track of created and not yet
-       submitted auxpow blocks.  Lock them to be sure even for multiple
-       RPC threads running in parallel.  */
+/**
+ * The variables below are used to keep track of created and not yet
+ * submitted auxpow blocks.  Lock them to be sure even for multiple
+ * RPC threads running in parallel.
+ */
 static CCriticalSection cs_auxblockCache;
 static std::map<uint256, CBlock*> mapNewBlock;
 static std::vector<std::unique_ptr<CBlockTemplate>> vNewBlockTemplate;
 
 static 
-void _AuxMiningCheck()
+void AuxMiningCheck()
 {
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
@@ -900,9 +902,9 @@ void _AuxMiningCheck()
 }
 
 static 
-UniValue _CreateAuxBlock(const CScript& scriptPubKey)
+UniValue AuxMiningCreateBlock(const CScript& scriptPubKey)
 {
-    _AuxMiningCheck();
+    AuxMiningCheck();
 
     LOCK(cs_auxblockCache);
 
@@ -968,9 +970,9 @@ UniValue _CreateAuxBlock(const CScript& scriptPubKey)
 }
 
 static
-bool _SumbitAuxBlock(const std::string& hashHex, const std::string& auxpowHex)
+bool AuxMiningSubmitBlock(const std::string& hashHex, const std::string& auxpowHex)
 {
-    _AuxMiningCheck();
+    AuxMiningCheck();
 
     LOCK(cs_auxblockCache);
 
@@ -991,7 +993,8 @@ bool _SumbitAuxBlock(const std::string& hashHex, const std::string& auxpowHex)
 
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    std::shared_ptr<const CBlock> shared_block = std::make_shared<const CBlock>(block);
+    std::shared_ptr<const CBlock> shared_block 
+      = std::make_shared<const CBlock>(block);
     bool fAccepted = ProcessNewBlock(Params(), shared_block, true, nullptr);
     UnregisterValidationInterface(&sc);
 
@@ -1043,14 +1046,14 @@ UniValue getauxblock(const JSONRPCRequest& request)
     /* Create a new block */
     if (request.params.size() == 0)
     {
-        return _CreateAuxBlock(coinbaseScript->reserveScript);
+        return AuxMiningCreateBlock(coinbaseScript->reserveScript);
     }
 
     /* Submit a block instead.  Note that this need not lock cs_main,
        since ProcessNewBlock below locks it instead.  */
     assert(request.params.size() == 2);
-    bool fAccepted = _SumbitAuxBlock(request.params[0].get_str(), 
-                                     request.params[1].get_str());
+    bool fAccepted = AuxMiningSubmitBlock(request.params[0].get_str(), 
+                                          request.params[1].get_str());
     if (fAccepted)
         coinbaseScript->KeepScript();
 
@@ -1061,7 +1064,7 @@ UniValue createauxblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            "createauxblock (address)\n"
+            "createauxblock <address>\n"
             "\ncreate a new block and return information required to merge-mine it.\n"
             "\nArguments:\n"
             "1. address      (string, required) specify coinbase transaction payout address\n"
@@ -1076,25 +1079,24 @@ UniValue createauxblock(const JSONRPCRequest& request)
             "  \"_target\"            (string) target in reversed byte order, deprecated\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("createauxblock", "address")
-            + HelpExampleRpc("createauxblock", "")
+            + HelpExampleCli("createauxblock", "\"address\"")
+            + HelpExampleRpc("createauxblock", "\"address\"")
             );
 
     // Check coinbase payout address
-    CScript scriptPubKey;
     CBitcoinAddress coinbaseAddress(request.params[0].get_str());
     if (!coinbaseAddress.IsValid())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid coinbase payout address");
-    scriptPubKey = GetScriptForDestination(coinbaseAddress.Get());
+    const CScript scriptPubKey = GetScriptForDestination(coinbaseAddress.Get());
 
-    return _CreateAuxBlock(scriptPubKey);
+    return AuxMiningCreateBlock(scriptPubKey);
 }
 
 UniValue submitauxblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 2)
         throw std::runtime_error(
-            "submitauxblock (hash auxpow)\n"
+            "submitauxblock <hash> <auxpow>\n"
             "\nsubmit a solved auxpow for a previously block created by 'createauxblock'.\n"
             "\nArguments:\n"
             "1. hash      (string, required) hash of the block to submit\n"
@@ -1103,11 +1105,11 @@ UniValue submitauxblock(const JSONRPCRequest& request)
             "xxxxx        (boolean) whether the submitted block was correct\n"
             "\nExamples:\n"
             + HelpExampleCli("submitauxblock", "\"hash\" \"serialised auxpow\"")
-            + HelpExampleRpc("submitauxblock", "")
+            + HelpExampleRpc("submitauxblock", "\"hash\" \"serialised auxpow\"")
             );
 
-    return _SumbitAuxBlock(request.params[0].get_str(), 
-                           request.params[1].get_str());
+    return AuxMiningSubmitBlock(request.params[0].get_str(), 
+                                request.params[1].get_str());
 }
 
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -870,6 +870,134 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
 /* ************************************************************************** */
 /* Merge mining.  */
 
+/* The variables below are used to keep track of created and not yet
+       submitted auxpow blocks.  Lock them to be sure even for multiple
+       RPC threads running in parallel.  */
+static CCriticalSection cs_auxblockCache;
+static std::map<uint256, CBlock*> mapNewBlock;
+static std::vector<std::unique_ptr<CBlockTemplate>> vNewBlockTemplate;
+
+static 
+void _AuxMiningCheck()
+{
+    if(!g_connman)
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+
+    if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0 && !Params().MineBlocksOnDemand())
+        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Namecoin is not connected!");
+
+    if (IsInitialBlockDownload() && !Params().MineBlocksOnDemand())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Namecoin is downloading blocks...");
+
+    /* This should never fail, since the chain is already
+       past the point of merge-mining start.  Check nevertheless.  */
+    {
+        LOCK(cs_main);
+        if (chainActive.Height() + 1 < Params().GetConsensus().nAuxpowStartHeight)
+            throw std::runtime_error("mining auxblock method is not yet available");
+    }
+}
+
+static 
+UniValue _CreateAuxBlock(const CScript& scriptPubKey)
+{
+    _AuxMiningCheck();
+
+    LOCK(cs_auxblockCache);
+
+    /* Create a new block */
+    static unsigned nTransactionsUpdatedLast;
+    static const CBlockIndex* pindexPrev = nullptr;
+    static uint64_t nStart;
+    static CBlock* pblock = nullptr;
+    static unsigned nExtraNonce = 0;
+
+    // Update block
+    {
+    LOCK(cs_main);
+    if (pindexPrev != chainActive.Tip()
+        || (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast
+            && GetTime() - nStart > 60))
+    {
+        if (pindexPrev != chainActive.Tip())
+        {
+            // Clear old blocks since they're obsolete now.
+            mapNewBlock.clear();
+            vNewBlockTemplate.clear();
+            pblock = nullptr;
+        }
+
+        // Create new block with nonce = 0 and extraNonce = 1
+        std::unique_ptr<CBlockTemplate> newBlock(BlockAssembler(Params()).CreateNewBlock(scriptPubKey));
+        if (!newBlock)
+            throw JSONRPCError(RPC_OUT_OF_MEMORY, "out of memory");
+
+        // Update state only when CreateNewBlock succeeded
+        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
+        pindexPrev = chainActive.Tip();
+        nStart = GetTime();
+
+        // Finalise it by setting the version and building the merkle root
+        IncrementExtraNonce(&newBlock->block, pindexPrev, nExtraNonce);
+        newBlock->block.SetAuxpowVersion(true);
+
+        // Save
+        pblock = &newBlock->block;
+        mapNewBlock[pblock->GetHash()] = pblock;
+        vNewBlockTemplate.push_back(std::move(newBlock));
+    }
+    }
+
+    arith_uint256 target;
+    bool fNegative, fOverflow;
+    target.SetCompact(pblock->nBits, &fNegative, &fOverflow);
+    if (fNegative || fOverflow || target == 0)
+        throw std::runtime_error("invalid difficulty bits in block");
+
+    UniValue result(UniValue::VOBJ);
+    result.push_back(Pair("hash", pblock->GetHash().GetHex()));
+    result.push_back(Pair("chainid", pblock->GetChainId()));
+    result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
+    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue));
+    result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
+    result.push_back(Pair("height", static_cast<int64_t> (pindexPrev->nHeight + 1)));
+    result.push_back(Pair("_target", HexStr(BEGIN(target), END(target))));
+
+    return result;
+}
+
+static
+bool _SumbitAuxBlock(const std::string& hashHex, const std::string& auxpowHex)
+{
+    _AuxMiningCheck();
+
+    LOCK(cs_auxblockCache);
+
+    uint256 hash;
+    hash.SetHex(hashHex);
+
+    const std::map<uint256, CBlock*>::iterator mit = mapNewBlock.find(hash);
+    if (mit == mapNewBlock.end())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "block hash unknown");
+    CBlock& block = *mit->second;
+
+    const std::vector<unsigned char> vchAuxPow = ParseHex(auxpowHex);
+    CDataStream ss(vchAuxPow, SER_GETHASH, PROTOCOL_VERSION);
+    CAuxPow pow;
+    ss >> pow;
+    block.SetAuxpow(new CAuxPow(pow));
+    assert(block.GetHash() == hash);
+
+    submitblock_StateCatcher sc(block.GetHash());
+    RegisterValidationInterface(&sc);
+    std::shared_ptr<const CBlock> shared_block = std::make_shared<const CBlock>(block);
+    bool fAccepted = ProcessNewBlock(Params(), shared_block, true, nullptr);
+    UnregisterValidationInterface(&sc);
+
+    return fAccepted;
+}
+
 UniValue getauxblock(const JSONRPCRequest& request)
 {
     if (request.fHelp
@@ -912,127 +1040,76 @@ UniValue getauxblock(const JSONRPCRequest& request)
     if (!coinbaseScript->reserveScript.size())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
-
-    if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0 && !Params().MineBlocksOnDemand())
-        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Namecoin is not connected!");
-
-    if (IsInitialBlockDownload() && !Params().MineBlocksOnDemand())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                           "Namecoin is downloading blocks...");
-    
-    /* This should never fail, since the chain is already
-       past the point of merge-mining start.  Check nevertheless.  */
-    {
-        LOCK(cs_main);
-        if (chainActive.Height() + 1 < Params().GetConsensus().nAuxpowStartHeight)
-            throw std::runtime_error("getauxblock method is not yet available");
-    }
-
-    /* The variables below are used to keep track of created and not yet
-       submitted auxpow blocks.  Lock them to be sure even for multiple
-       RPC threads running in parallel.  */
-    static CCriticalSection cs_auxblockCache;
-    LOCK(cs_auxblockCache);
-    static std::map<uint256, CBlock*> mapNewBlock;
-    static std::vector<std::unique_ptr<CBlockTemplate>> vNewBlockTemplate;
-
-    /* Create a new block?  */
+    /* Create a new block */
     if (request.params.size() == 0)
     {
-        static unsigned nTransactionsUpdatedLast;
-        static const CBlockIndex* pindexPrev = nullptr;
-        static uint64_t nStart;
-        static CBlock* pblock = nullptr;
-        static unsigned nExtraNonce = 0;
-
-        // Update block
-        {
-        LOCK(cs_main);
-        if (pindexPrev != chainActive.Tip()
-            || (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast
-                && GetTime() - nStart > 60))
-        {
-            if (pindexPrev != chainActive.Tip())
-            {
-                // Clear old blocks since they're obsolete now.
-                mapNewBlock.clear();
-                vNewBlockTemplate.clear();
-                pblock = nullptr;
-            }
-
-            // Create new block with nonce = 0 and extraNonce = 1
-            std::unique_ptr<CBlockTemplate> newBlock(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript));
-            if (!newBlock)
-                throw JSONRPCError(RPC_OUT_OF_MEMORY, "out of memory");
-
-            // Update state only when CreateNewBlock succeeded
-            nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-            pindexPrev = chainActive.Tip();
-            nStart = GetTime();
-
-            // Finalise it by setting the version and building the merkle root
-            IncrementExtraNonce(&newBlock->block, pindexPrev, nExtraNonce);
-            newBlock->block.SetAuxpowVersion(true);
-
-            // Save
-            pblock = &newBlock->block;
-            mapNewBlock[pblock->GetHash()] = pblock;
-            vNewBlockTemplate.push_back(std::move(newBlock));
-        }
-        }
-
-        arith_uint256 target;
-        bool fNegative, fOverflow;
-        target.SetCompact(pblock->nBits, &fNegative, &fOverflow);
-        if (fNegative || fOverflow || target == 0)
-            throw std::runtime_error("invalid difficulty bits in block");
-
-        UniValue result(UniValue::VOBJ);
-        result.push_back(Pair("hash", pblock->GetHash().GetHex()));
-        result.push_back(Pair("chainid", pblock->GetChainId()));
-        result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
-        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue));
-        result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
-        result.push_back(Pair("height", static_cast<int64_t> (pindexPrev->nHeight + 1)));
-        result.push_back(Pair("_target", HexStr(BEGIN(target), END(target))));
-
-        return result;
+        return _CreateAuxBlock(coinbaseScript->reserveScript);
     }
 
     /* Submit a block instead.  Note that this need not lock cs_main,
        since ProcessNewBlock below locks it instead.  */
-
     assert(request.params.size() == 2);
-    uint256 hash;
-    hash.SetHex(request.params[0].get_str());
-
-    const std::map<uint256, CBlock*>::iterator mit = mapNewBlock.find(hash);
-    if (mit == mapNewBlock.end())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "block hash unknown");
-    CBlock& block = *mit->second;
-
-    const std::vector<unsigned char> vchAuxPow
-      = ParseHex(request.params[1].get_str());
-    CDataStream ss(vchAuxPow, SER_GETHASH, PROTOCOL_VERSION);
-    CAuxPow pow;
-    ss >> pow;
-    block.SetAuxpow(new CAuxPow(pow));
-    assert(block.GetHash() == hash);
-
-    submitblock_StateCatcher sc(block.GetHash());
-    RegisterValidationInterface(&sc);
-    std::shared_ptr<const CBlock> shared_block
-      = std::make_shared<const CBlock>(block);
-    bool fAccepted = ProcessNewBlock(Params(), shared_block, true, nullptr);
-    UnregisterValidationInterface(&sc);
-
+    bool fAccepted = _SumbitAuxBlock(request.params[0].get_str(), 
+                                     request.params[1].get_str());
     if (fAccepted)
         coinbaseScript->KeepScript();
 
     return fAccepted;
 }
+
+UniValue createauxblock(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "createauxblock (address)\n"
+            "\ncreate a new block and return information required to merge-mine it.\n"
+            "\nArguments:\n"
+            "1. address      (string, required) specify coinbase transaction payout address\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"hash\"               (string) hash of the created block\n"
+            "  \"chainid\"            (numeric) chain ID for this block\n"
+            "  \"previousblockhash\"  (string) hash of the previous block\n"
+            "  \"coinbasevalue\"      (numeric) value of the block's coinbase\n"
+            "  \"bits\"               (string) compressed target of the block\n"
+            "  \"height\"             (numeric) height of the block\n"
+            "  \"_target\"            (string) target in reversed byte order, deprecated\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("createauxblock", "address")
+            + HelpExampleRpc("createauxblock", "")
+            );
+
+    // Check coinbase payout address
+    CScript scriptPubKey;
+    CBitcoinAddress coinbaseAddress(request.params[0].get_str());
+    if (!coinbaseAddress.IsValid())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid coinbase payout address");
+    scriptPubKey = GetScriptForDestination(coinbaseAddress.Get());
+
+    return _CreateAuxBlock(scriptPubKey);
+}
+
+UniValue submitauxblock(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 2)
+        throw std::runtime_error(
+            "submitauxblock (hash auxpow)\n"
+            "\nsubmit a solved auxpow for a previously block created by 'createauxblock'.\n"
+            "\nArguments:\n"
+            "1. hash      (string, required) hash of the block to submit\n"
+            "2. auxpow    (string, required) serialised auxpow found\n"
+            "\nResult:\n"
+            "xxxxx        (boolean) whether the submitted block was correct\n"
+            "\nExamples:\n"
+            + HelpExampleCli("submitauxblock", "\"hash\" \"serialised auxpow\"")
+            + HelpExampleRpc("submitauxblock", "")
+            );
+
+    return _SumbitAuxBlock(request.params[0].get_str(), 
+                           request.params[1].get_str());
+}
+
 
 /* ************************************************************************** */
 
@@ -1045,6 +1122,8 @@ static const CRPCCommand commands[] =
     { "mining",             "getblocktemplate",       &getblocktemplate,       true,  {"template_request"} },
     { "mining",             "submitblock",            &submitblock,            true,  {"hexdata","parameters"} },
     { "mining",             "getauxblock",            &getauxblock,            true,  {"hash", "auxpow"} },
+    { "mining",             "createauxblock",         &createauxblock,         true,  {"address"} },
+    { "mining",             "submitauxblock",         &submitauxblock,         true,  {"hash", "auxpow"} },
 
     { "generating",         "generate",               &generate,               true,  {"nblocks","maxtries"} },
     { "generating",         "generatetoaddress",      &generatetoaddress,      true,  {"nblocks","address","maxtries"} },

--- a/test/functional/test_framework/auxpow.py
+++ b/test/functional/test_framework/auxpow.py
@@ -62,6 +62,7 @@ def computeAuxpow (block, target, ok):
 def mineAuxpowBlock (node):
   """
   Mine an auxpow block on the given RPC connection.
+  Using command: getauxblock
   """
 
   auxblock = node.getauxblock ()
@@ -71,6 +72,37 @@ def mineAuxpowBlock (node):
   assert res
 
   return auxblock['hash']
+
+def mineAuxpowBlock2 (node, coinbaseAddress):
+  """
+  Mine an auxpow block on the given RPC connection.
+  Using command: createauxblock / submitauxblock
+  """
+
+  auxblock = node.createauxblock (coinbaseAddress)
+  target = reverseHex (auxblock['_target'])
+  apow = computeAuxpow (auxblock['hash'], target, True)
+  res = node.submitauxblock (auxblock['hash'], apow)
+  assert res
+
+  return auxblock['hash']
+
+def getCoinbaseAddr (node, blockHash):
+    """
+    Extract the coinbase tx' payout address for the given block.
+    """
+
+    blockData = node.getblock (blockHash)
+    txn = blockData['tx']
+    assert len (txn) >= 1
+
+    txData = node.getrawtransaction (txn[0], 1)
+    assert len (txData['vout']) >= 1 and len (txData['vin']) == 1
+    assert 'coinbase' in txData['vin'][0]
+
+    addr = txData['vout'][0]['scriptPubKey']['addresses']
+    assert len (addr) == 1
+    return addr[0]
 
 def mineBlock (header, target, ok):
   """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -119,6 +119,7 @@ BASE_SCRIPTS= [
 
     # auxpow tests
     'getauxblock.py',
+    'create_submit_auxblock.py',
 
     # name tests
     'name_expiration.py',


### PR DESCRIPTION
Add new aux mining rpc commands: `createauxblock` and `submitauxblock`.

* Separate create and submit AUX block, make it clear and more readable, instead mixing them in one rpc call command `getauxblock`.
* With `createauxblock`, miners must specify a namecoin address as the coinbase output address instead of create random address using build-in wallet.
  * so we can build `namecoind` without wallet: `./configure --disable-wallet`
* using `getauxblock` is the same as before, it's compatible.