### PR TITLE
Update DNS seed list

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -159,10 +159,8 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0x41c62dbd9068c89a449525e3cd5ac61b20ece28c3c38b3f35b2161f0e6d3cb0d"));
 
         // Note that of those with the service bits flag, most only support a subset of possible options
-        vSeeds.emplace_back("namecoindnsseed.digi-masters.com", false);
-        vSeeds.emplace_back("namecoindnsseed.digi-masters.uk", false);
         vSeeds.emplace_back("nmc.seed.quisquis.de", false);
-        vSeeds.emplace_back("dnsseed.namecoin.webbtc.com", false);
+        vSeeds.emplace_back("seed.nmc.markasoftware.com", false);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,52);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,13);


### PR DESCRIPTION
3 out of the 4 current seeds don't work, and quisquis.de also didn't work under certain DNS resolvers (the default Comcast one had issues, OpenNIC did not). I have removed the nonfuncitional seeds and added my own seed. Thanks!