### PR TITLE
GetDesirableServiceFlags: Do not desire NODE_WITNESS

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -294,7 +294,7 @@ enum ServiceFlags : uint64_t {
  * Thus, generally, avoid calling with peerServices == NODE_NONE.
  */
 static ServiceFlags GetDesirableServiceFlags(ServiceFlags services) {
-    return ServiceFlags(NODE_NETWORK | NODE_WITNESS);
+    return ServiceFlags(NODE_NETWORK /*| NODE_WITNESS*/);
 }
 
 /**


### PR DESCRIPTION
Basically, P2P propagated addresses and addresses from DNS seeds were not being used to connect out to any other nodes. This is the smallest change that fixes that, and allows my node to get a full set of outbound peers now.

I believe that this fixes these issues:
https://github.com/namecoin/namecoin-core/issues/145
https://github.com/namecoin/namecoin-core/issues/174
https://github.com/namecoin/namecoin-core/issues/188