### PR TITLE
Docs: Re-enable OS X builds in Release Process docs.

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -88,7 +88,7 @@ Ensure gitian-builder is up-to-date:
     wget -P inputs http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
     popd
 
- ( **Not in Namecoin yet.** ) Create the OS X SDK tarball, see the [OS X readme](README_osx.md) for details, and copy it into the inputs directory.
+Create the OS X SDK tarball, see the [OS X readme](README_osx.md) for details, and copy it into the inputs directory.
 
 ### Optional: Seed the Gitian sources cache and offline git repositories
 
@@ -120,8 +120,6 @@ The gbuild invocations below <b>DO NOT DO THIS</b> by default.
     mv build/out/namecoin-*-win-unsigned.tar.gz inputs/namecoin-win-unsigned.tar.gz
     mv build/out/namecoin-*.zip build/out/namecoin-*.exe ../
 
-( **OS X is not in Namecoin yet.** )
-
     ./bin/gbuild --num-make 2 --memory 3000 --commit namecoin=nc${VERSION} ../namecoin-core/contrib/gitian-descriptors/gitian-osx.yml
     ./bin/gsign --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../namecoin-core/contrib/gitian-descriptors/gitian-osx.yml
     mv build/out/namecoin-*-osx-unsigned.tar.gz inputs/namecoin-osx-unsigned.tar.gz
@@ -133,7 +131,7 @@ Build output expected:
   1. source tarball (`namecoin-${VERSION}.tar.gz`)
   2. linux 32-bit and 64-bit dist tarballs (`namecoin-${VERSION}-linux[32|64].tar.gz`)
   3. windows 32-bit and 64-bit unsigned installers and dist zips (`namecoin-${VERSION}-win[32|64]-setup-unsigned.exe`, `namecoin-${VERSION}-win[32|64].zip`)
-  4. ( **Not in Namecoin yet.** ) OS X unsigned installer and dist tarball (`namecoin-${VERSION}-osx-unsigned.dmg`, `namecoin-${VERSION}-osx64.tar.gz`)
+  4. OS X unsigned installer and dist tarball (`namecoin-${VERSION}-osx-unsigned.dmg`, `namecoin-${VERSION}-osx64.tar.gz`)
   5. Gitian signatures (in `gitian.sigs/${VERSION}-<linux|{win,osx}-unsigned>/(your Gitian key)/`)
 
 ### Verify other gitian builders signatures to your own. (Optional)
@@ -148,7 +146,7 @@ Verify the signatures
     pushd ./gitian-builder
     ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../namecoin-core/contrib/gitian-descriptors/gitian-linux.yml
     ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../namecoin-core/contrib/gitian-descriptors/gitian-win.yml
-    #./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../namecoin-core/contrib/gitian-descriptors/gitian-osx.yml # OS X is not in Namecoin yet, so don't do this.
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../namecoin-core/contrib/gitian-descriptors/gitian-osx.yml
     popd
 
 ### Next steps:
@@ -158,7 +156,7 @@ Commit your signature to gitian.sigs:
     pushd gitian.sigs
     git add ${VERSION}-linux/${SIGNER}
     git add ${VERSION}-win-unsigned/${SIGNER}
-    #git add ${VERSION}-osx-unsigned/${SIGNER} # OS X is not in Namecoin yet, so don't do this.
+    git add ${VERSION}-osx-unsigned/${SIGNER}
     git commit -a
     git push  # Assuming you can push to the gitian.sigs tree
     popd
@@ -243,8 +241,8 @@ namecoin-${VERSION}-aarch64-linux-gnu.tar.gz
 namecoin-${VERSION}-arm-linux-gnueabihf.tar.gz
 namecoin-${VERSION}-i686-pc-linux-gnu.tar.gz
 namecoin-${VERSION}-x86_64-linux-gnu.tar.gz
-namecoin-${VERSION}-osx64.tar.gz     # Not in Namecoin yet.
-namecoin-${VERSION}-osx.dmg          # Not in Namecoin yet.
+namecoin-${VERSION}-osx64.tar.gz
+namecoin-${VERSION}-osx.dmg
 namecoin-${VERSION}.tar.gz
 namecoin-${VERSION}-win32-setup.exe
 namecoin-${VERSION}-win32.zip


### PR DESCRIPTION
OS X Gitian builds should work now, so there's no reason to exclude them from the Release Process docs.