### PR TITLE
Add src/rpc/names.cpp to check-rpc-mappings.py source list.

### DIFF
--- a/contrib/devtools/check-rpc-mappings.py
+++ b/contrib/devtools/check-rpc-mappings.py
@@ -15,6 +15,7 @@ SOURCES = [
     "src/rpc/blockchain.cpp",
     "src/rpc/mining.cpp",
     "src/rpc/misc.cpp",
+    "src/rpc/names.cpp",
     "src/rpc/net.cpp",
     "src/rpc/rawtransaction.cpp",
     "src/wallet/rpcwallet.cpp",


### PR DESCRIPTION
The script `contrib/devtools/check-rpc-mappings.py` verifies consistency between RPC dispatch tables and the argument conversions listed in `src/rpc/client.cpp`.  For this, it needs a list of sources that contain dispatch tables.  `src/rpc/names.cpp` was missing from this list, leading to errors as in #203.

This commit adds the missing source file, which makes the script run successfully.  Note that `src/wallet/rpcnames.cpp`, which also contains Namecoin RPCs, need not be listed; the dispatch table for those RPCs is included in `src/wallet/rpcwallet.cpp.`