### PR TITLE
Add "sendCoins" option for name operations

### DIFF
--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -436,7 +436,6 @@ name_pending (const JSONRPCRequest& request)
             .withField ("\"ismine\": xxxxx",
                         "(boolean) whether the name is owned by the wallet")
             .finish (",") +
-        "  },\n"
         "  ...\n"
         "]\n"
         + HelpExampleCli ("name_pending", "")

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -4,10 +4,12 @@
 
 #include <base58.h>
 #include <coins.h>
+#include <consensus/validation.h>
 #include <init.h>
 #include <key_io.h>
 #include <names/common.h>
 #include <names/main.h>
+#include <net.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <rpc/mining.h>
@@ -15,12 +17,14 @@
 #include <script/names.h>
 #include <txmempool.h>
 #include <util.h>
+#include <utilmoneystr.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 
 #include <univalue.h>
 
+#include <algorithm>
 #include <memory>
 
 /* ************************************************************************** */
@@ -116,7 +120,108 @@ std::string getNameOpOptionsHelp ()
 {
   return "  {\n"
          "    \"destAddress\"  (string, optional) The address to send the name output to\n"
+         "    \"sendCoins\"    (object, optional) Addresses to which coins should be sent additionally\n"
+         "      {\n"
+         "        \"addr1\": x,\n"
+         "        \"addr2\": y,\n"
+         "        ...\n"
+         "      }\n"
          "  }\n";
+}
+
+/**
+ * Sends a name output to the given name script.  This is the "final" step that
+ * is common between name_new, name_firstupdate and name_update.  This method
+ * also implements the "sendCoins" option, if included.
+ */
+CTransactionRef
+SendNameOutput (CWallet& wallet, const CScript& nameOutScript,
+                const CTxIn* nameInput, const UniValue& opt)
+{
+  RPCTypeCheckObj (opt,
+    {
+      {"sendCoins", UniValueType (UniValue::VOBJ)},
+    },
+    true, false);
+
+  if (wallet.GetBroadcastTransactions () && !g_connman)
+    throw JSONRPCError (RPC_CLIENT_P2P_DISABLED,
+                        "Error: Peer-to-peer functionality missing"
+                        " or disabled");
+
+  std::vector<CRecipient> vecSend;
+  vecSend.push_back ({nameOutScript, NAME_LOCKED_AMOUNT, false});
+
+  if (opt.exists ("sendCoins"))
+    for (const std::string& addr : opt["sendCoins"].getKeys ())
+      {
+        const CTxDestination dest = DecodeDestination (addr);
+        if (!IsValidDestination (dest))
+          throw JSONRPCError (RPC_INVALID_ADDRESS_OR_KEY,
+                              "Invalid address: " + addr);
+
+        const CAmount nAmount = AmountFromValue (opt["sendCoins"][addr]);
+        if (nAmount <= 0)
+          throw JSONRPCError (RPC_TYPE_ERROR, "Invalid amount for send");
+
+        vecSend.push_back ({GetScriptForDestination (dest), nAmount, false});
+      }
+
+  /* Shuffle the recipient list for privacy.  */
+  std::shuffle (vecSend.begin (), vecSend.end (), FastRandomContext ());
+
+  /* Check balance against total amount sent.  If we have a name input, we have
+     to take its value into account.  */
+
+  const CAmount curBalance = wallet.GetBalance ();
+
+  CAmount totalSpend = 0;
+  for (const auto& recv : vecSend)
+    totalSpend += recv.nAmount;
+
+  CAmount lockedValue = 0;
+  std::string strError;
+  if (nameInput != nullptr)
+    {
+      const CWalletTx* dummyWalletTx;
+      if (!wallet.FindValueInNameInput (*nameInput, lockedValue,
+                                        dummyWalletTx, strError))
+        throw JSONRPCError(RPC_WALLET_ERROR, strError);
+    }
+
+  if (totalSpend > curBalance + lockedValue)
+    throw JSONRPCError (RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+
+  /* Create and send the transaction.  This code is based on the corresponding
+     part of SendMoneyToScript and should stay in sync.  */
+
+  CCoinControl coinControl;
+  CReserveKey keyChange(&wallet);
+  CAmount nFeeRequired;
+  int nChangePosRet = -1;
+
+  CTransactionRef tx;
+  if (!wallet.CreateTransaction (vecSend, nameInput, tx, keyChange,
+                                 nFeeRequired, nChangePosRet, strError,
+                                 coinControl))
+    {
+      if (totalSpend + nFeeRequired > curBalance)
+        strError = strprintf ("Error: This transaction requires a transaction"
+                              " fee of at least %s",
+                              FormatMoney (nFeeRequired));
+      throw JSONRPCError (RPC_WALLET_ERROR, strError);
+    }
+
+  CValidationState state;
+  if (!wallet.CommitTransaction (tx, {}, {}, {}, keyChange, g_connman.get (),
+                                 state))
+    {
+      strError = strprintf ("Error: The transaction was rejected!"
+                            "  Reason given: %s", FormatStateMessage (state));
+      throw JSONRPCError (RPC_WALLET_ERROR, strError);
+    }
+
+  return tx;
 }
 
 } // anonymous namespace
@@ -263,6 +368,10 @@ name_new (const JSONRPCRequest& request)
   if (name.size () > MAX_NAME_LENGTH)
     throw JSONRPCError (RPC_INVALID_PARAMETER, "the name is too long");
 
+  UniValue options(UniValue::VOBJ);
+  if (request.params.size () >= 2)
+    options = request.params[1].get_obj ();
+
   valtype rand(20);
   GetRandBytes (&rand[0], rand.size ());
 
@@ -277,16 +386,13 @@ name_new (const JSONRPCRequest& request)
   EnsureWalletIsUnlocked (pwallet);
 
   DestinationAddressHelper destHelper(*pwallet);
-  if (request.params.size () >= 2)
-    destHelper.setOptions (request.params[1].get_obj ());
+  destHelper.setOptions (options);
 
   const CScript newScript
       = CNameScript::buildNameNew (destHelper.getScript (), hash);
 
   CCoinControl coinControl;
-  CTransactionRef tx = SendMoneyToScript (pwallet, newScript, nullptr,
-                                          NAME_LOCKED_AMOUNT, false,
-                                          coinControl, {}, {});
+  CTransactionRef tx = SendNameOutput (*pwallet, newScript, nullptr, options);
   destHelper.finalise ();
 
   const std::string randStr = HexStr (rand);
@@ -405,6 +511,10 @@ name_firstupdate (const JSONRPCRequest& request)
   if (value.size () > MAX_VALUE_LENGTH_UI)
     throw JSONRPCError (RPC_INVALID_PARAMETER, "the value is too long");
 
+  UniValue options(UniValue::VOBJ);
+  if (request.params.size () >= 5)
+    options = request.params[4].get_obj ();
+
   {
     LOCK (mempool.cs);
     if (mempool.registersName (name))
@@ -444,17 +554,14 @@ name_firstupdate (const JSONRPCRequest& request)
   EnsureWalletIsUnlocked (pwallet);
 
   DestinationAddressHelper destHelper(*pwallet);
-  if (request.params.size () >= 5)
-    destHelper.setOptions (request.params[4].get_obj ());
+  destHelper.setOptions (options);
 
   const CScript nameScript
     = CNameScript::buildNameFirstupdate (destHelper.getScript (), name, value,
                                          rand);
 
   CCoinControl coinControl;
-  CTransactionRef tx = SendMoneyToScript (pwallet, nameScript, &txIn,
-                                          NAME_LOCKED_AMOUNT, false,
-                                          coinControl, {}, {});
+  CTransactionRef tx = SendNameOutput (*pwallet, nameScript, &txIn, options);
   destHelper.finalise ();
 
   return tx->GetHash ().GetHex ();
@@ -501,6 +608,10 @@ name_update (const JSONRPCRequest& request)
   if (value.size () > MAX_VALUE_LENGTH_UI)
     throw JSONRPCError (RPC_INVALID_PARAMETER, "the value is too long");
 
+  UniValue options(UniValue::VOBJ);
+  if (request.params.size () >= 3)
+    options = request.params[2].get_obj ();
+
   /* Reject updates to a name for which the mempool already has
      a pending update.  This is not a hard rule enforced by network
      rules, but it is necessary with the current mempool implementation.  */
@@ -527,16 +638,13 @@ name_update (const JSONRPCRequest& request)
   EnsureWalletIsUnlocked (pwallet);
 
   DestinationAddressHelper destHelper(*pwallet);
-  if (request.params.size () >= 3)
-    destHelper.setOptions (request.params[2].get_obj ());
+  destHelper.setOptions (options);
 
   const CScript nameScript
     = CNameScript::buildNameUpdate (destHelper.getScript (), name, value);
 
   CCoinControl coinControl;
-  CTransactionRef tx = SendMoneyToScript (pwallet, nameScript, &txIn,
-                                          NAME_LOCKED_AMOUNT, false,
-                                          coinControl, {}, {});
+  CTransactionRef tx = SendNameOutput (*pwallet, nameScript, &txIn, options);
   destHelper.finalise ();
 
   return tx->GetHash ().GetHex ();

--- a/test/functional/name_sendcoins.py
+++ b/test/functional/name_sendcoins.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for the "sendCoins" option with name operations.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameSendCoinsTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 1)
+
+  def verifyTx (self, txid, expected):
+    """Verify that the given tx sends currency to the expected recipients."""
+
+    tx = self.nodes[0].getrawtransaction (txid, 1)
+    vout = tx['vout']
+
+    # There should be two additional outputs: name and change
+    assert_equal (len (vout), len (expected) + 2)
+
+    actual = {}
+    for out in vout:
+      if 'nameOp' in out['scriptPubKey']:
+        continue
+      addr = out['scriptPubKey']['addresses']
+      assert_equal (len (addr), 1)
+      addr = addr[0]
+      if not addr in expected:
+        # This must be the change address.  Through the assertion above about
+        # the expected sizes, we make sure that the test fails if there is
+        # not exactly one key with this property.
+        continue
+      actual[addr] = out['value']
+    assert_equal (actual, expected)
+
+  def run_test (self):
+
+    # Send name_new with sendCoins option and verify it worked as expected.
+    addr1 = self.nodes[0].getnewaddress ()
+    addr2 = self.nodes[0].getnewaddress ()
+    sendCoins = {addr1: 1, addr2: 2}
+    new = self.nodes[0].name_new ("testname", {"sendCoins": sendCoins})
+    self.generate (0, 10)
+    self.verifyTx (new[0], sendCoins)
+
+    # Check that it also works with first_update.
+    txid = self.firstupdateName (0, "testname", new, "value",
+                                 {"sendCoins": sendCoins})
+    self.generate (0, 5)
+    self.verifyTx (txid, sendCoins)
+
+    # Test different variantions (numbers of target addresses) with name_update.
+    for n in range (5):
+      sendCoins = {}
+      for i in range (n):
+        sendCoins[self.nodes[0].getnewaddress ()] = 42 + i
+      txid = self.nodes[0].name_update ("testname", "value",
+                                       {"sendCoins": sendCoins})
+      self.generate (0, 1)
+      self.verifyTx (txid, sendCoins)
+
+    # Verify the range check for amount and the address validation.
+    assert_raises_rpc_error (-3, 'Invalid amount for send',
+                             self.nodes[0].name_update,
+                             "testname", "value", {"sendCoins": {addr1: 0}})
+    assert_raises_rpc_error (-5, 'Invalid address',
+                             self.nodes[0].name_update,
+                             "testname", "value", {"sendCoins": {"x": 1}})
+
+    # Verify the insufficient funds check, both where it fails a priori
+    # and where we just don't have enough for the fee.
+    balance = self.nodes[0].getbalance ()
+    assert_raises_rpc_error (-6, 'Insufficient funds',
+                             self.nodes[0].name_update,
+                             "testname", "value",
+                             {"sendCoins": {addr1: balance + 1}})
+    assert_raises_rpc_error (-4, 'requires a transaction fee',
+                             self.nodes[0].name_update,
+                             "testname", "value",
+                             {"sendCoins": {addr1: balance}})
+
+    # Check that we can send a name_update that spends almost all funds in
+    # the wallet.  We only need to keep a tiny amount to pay for the fee
+    # (but less than the locked amount of 0.01).
+    keep = Decimal ("0.009")
+    sendCoins = {addr1: balance - keep}
+    txid = self.nodes[0].name_update ("testname", "value",
+                                      {"sendCoins": sendCoins})
+    self.generate (0, 1)
+    self.verifyTx (txid, sendCoins)
+
+if __name__ == '__main__':
+  NameSendCoinsTest ().main ()

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -24,5 +24,8 @@ echo "\nName reorgs..."
 echo "\nName scanning..."
 ./name_scanning.py
 
+echo "\nName operation with sendCoins..."
+./name_sendcoins.py
+
 echo "\nName wallet..."
 ./name_wallet.py

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -166,6 +166,7 @@ BASE_SCRIPTS = [
     'name_registration.py',
     'name_reorg.py',
     'name_scanning.py',
+    'name_sendcoins.py',
     'name_wallet.py',
 ]
 


### PR DESCRIPTION
This (building on top of #220 - I will rebase after #220 is merged before merging this one) adds the new `sendCoins` option to name operations (`name_new`, `name_firstupdate` and `name_update`).  This allows to (optionally) send coins in the same transaction as a name update, similar to `sendmany`.

This is a feature we need for Chimaera - but since it applies to Namecoin as well and might be useful there also, I think we should implement it here.

If there are no NACKs or other feedback in the next few days, I will merge this early next week.