### PR TITLE
Create AuxpowMiner helper class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,7 @@ BITCOIN_CORE_H = \
   random.h \
   reverse_iterator.h \
   reverselock.h \
+  rpc/auxpow_miner.h \
   rpc/blockchain.h \
   rpc/client.h \
   rpc/mining.h \
@@ -218,6 +219,7 @@ libbitcoin_server_a_SOURCES = \
   policy/rbf.cpp \
   pow.cpp \
   rest.cpp \
+  rpc/auxpow_miner.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,6 +29,8 @@
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
+#include <rpc/auxpow_miner.h>
+#include <rpc/mining.h>
 #include <rpc/server.h>
 #include <rpc/register.h>
 #include <rpc/blockchain.h>
@@ -217,6 +219,10 @@ void Shutdown()
     g_connman.reset();
     if (g_txindex) {
         g_txindex.reset();
+    }
+
+    if (g_auxpow_miner != nullptr) {
+        g_auxpow_miner.reset();
     }
 
     StopTorControl();
@@ -1273,6 +1279,8 @@ bool AppInitMain()
      */
     RegisterAllCoreRPCCommands(tableRPC);
     g_wallet_init_interface.RegisterRPC(tableRPC);
+
+    g_auxpow_miner.reset(new AuxpowMiner());
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/rpc/auxpow_miner.cpp
+++ b/src/rpc/auxpow_miner.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2018 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/auxpow_miner.h>
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <net.h>
+#include <rpc/protocol.h>
+#include <utilstrencodings.h>
+#include <utiltime.h>
+#include <validation.h>
+
+#include <cassert>
+
+namespace
+{
+
+void auxMiningCheck()
+{
+  if (!g_connman)
+    throw JSONRPCError (RPC_CLIENT_P2P_DISABLED,
+                        "Error: Peer-to-peer functionality missing or"
+                        " disabled");
+
+  if (g_connman->GetNodeCount (CConnman::CONNECTIONS_ALL) == 0
+        && !Params ().MineBlocksOnDemand ())
+    throw JSONRPCError (RPC_CLIENT_NOT_CONNECTED,
+                        "Namecoin is not connected!");
+
+  if (IsInitialBlockDownload () && !Params ().MineBlocksOnDemand ())
+    throw JSONRPCError (RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                        "Namecoin is downloading blocks...");
+
+  /* This should never fail, since the chain is already
+     past the point of merge-mining start.  Check nevertheless.  */
+  {
+    LOCK (cs_main);
+    const auto auxpowStart = Params ().GetConsensus ().nAuxpowStartHeight;
+    if (chainActive.Height () + 1 < auxpowStart)
+      throw std::runtime_error ("mining auxblock method is not yet available");
+  }
+}
+
+}  // anonymous namespace
+
+const CBlock*
+AuxpowMiner::getCurrentBlock (const CScript& scriptPubKey, uint256& target)
+{
+  AssertLockHeld (cs);
+
+  {
+    LOCK (cs_main);
+    if (pindexPrev != chainActive.Tip ()
+        || (mempool.GetTransactionsUpdated () != txUpdatedLast
+            && GetTime () - startTime > 60))
+      {
+        if (pindexPrev != chainActive.Tip ())
+          {
+            /* Clear old blocks since they're obsolete now.  */
+            blocks.clear ();
+            templates.clear ();
+            pblockCur = nullptr;
+          }
+
+        /* Create new block with nonce = 0 and extraNonce = 1.  */
+        std::unique_ptr<CBlockTemplate> newBlock
+            = BlockAssembler (Params ()).CreateNewBlock (scriptPubKey);
+        if (newBlock == nullptr)
+          throw JSONRPCError (RPC_OUT_OF_MEMORY, "out of memory");
+
+        /* Update state only when CreateNewBlock succeeded.  */
+        txUpdatedLast = mempool.GetTransactionsUpdated ();
+        pindexPrev = chainActive.Tip ();
+        startTime = GetTime ();
+
+        /* Finalise it by setting the version and building the merkle root.  */
+        IncrementExtraNonce (&newBlock->block, pindexPrev, extraNonce);
+        newBlock->block.SetAuxpowVersion (true);
+
+        /* Save in our map of constructed blocks.  */
+        pblockCur = &newBlock->block;
+        blocks[pblockCur->GetHash ()] = pblockCur;
+        templates.push_back (std::move (newBlock));
+      }
+  }
+
+  /* At this point, pblockCur is always initialised:  If we make it here
+     without creating a new block above, it means that, in particular,
+     pindexPrev == chainActive.Tip().  But for that to happen, we must
+     already have created a pblockCur in a previous call, as pindexPrev is
+     initialised only when pblockCur is.  */
+  assert (pblockCur);
+
+  arith_uint256 arithTarget;
+  bool fNegative, fOverflow;
+  arithTarget.SetCompact (pblockCur->nBits, &fNegative, &fOverflow);
+  if (fNegative || fOverflow || arithTarget == 0)
+    throw std::runtime_error ("invalid difficulty bits in block");
+  target = ArithToUint256 (arithTarget);
+
+  return pblockCur;
+}
+
+const CBlock*
+AuxpowMiner::lookupSavedBlock (const std::string& hashHex) const
+{
+  AssertLockHeld (cs);
+
+  uint256 hash;
+  hash.SetHex (hashHex);
+
+  const auto iter = blocks.find (hash);
+  if (iter == blocks.end ())
+    throw JSONRPCError (RPC_INVALID_PARAMETER, "block hash unknown");
+
+  return iter->second;
+}
+
+UniValue
+AuxpowMiner::createAuxBlock (const CScript& scriptPubKey)
+{
+  auxMiningCheck ();
+  LOCK (cs);
+
+  uint256 target;
+  const CBlock* pblock = getCurrentBlock (scriptPubKey, target);
+
+  UniValue result(UniValue::VOBJ);
+  result.pushKV ("hash", pblock->GetHash ().GetHex ());
+  result.pushKV ("chainid", pblock->GetChainId ());
+  result.pushKV ("previousblockhash", pblock->hashPrevBlock.GetHex ());
+  result.pushKV ("coinbasevalue",
+                 static_cast<int64_t> (pblock->vtx[0]->vout[0].nValue));
+  result.pushKV ("bits", strprintf ("%08x", pblock->nBits));
+  result.pushKV ("height", static_cast<int64_t> (pindexPrev->nHeight + 1));
+  result.pushKV ("_target", HexStr (BEGIN (target), END (target)));
+
+  return result;
+}
+
+bool
+AuxpowMiner::submitAuxBlock (const std::string& hashHex,
+                             const std::string& auxpowHex) const
+{
+  auxMiningCheck ();
+
+  std::shared_ptr<CBlock> shared_block;
+  {
+    LOCK (cs);
+    const CBlock* pblock = lookupSavedBlock (hashHex);
+    shared_block = std::make_shared<CBlock> (*pblock);
+  }
+
+  const std::vector<unsigned char> vchAuxPow = ParseHex (auxpowHex);
+  CDataStream ss(vchAuxPow, SER_GETHASH, PROTOCOL_VERSION);
+  CAuxPow pow;
+  ss >> pow;
+  shared_block->SetAuxpow (new CAuxPow (pow));
+  assert (shared_block->GetHash ().GetHex () == hashHex);
+
+  return ProcessNewBlock (Params (), shared_block, true, nullptr);
+}

--- a/src/rpc/auxpow_miner.h
+++ b/src/rpc/auxpow_miner.h
@@ -63,6 +63,8 @@ private:
    */
   const CBlock* lookupSavedBlock (const std::string& hashHex) const;
 
+  friend class AuxpowMinerForTest;
+
 public:
 
   AuxpowMiner () = default;

--- a/src/rpc/auxpow_miner.h
+++ b/src/rpc/auxpow_miner.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_AUXPOW_MINER_H
+#define BITCOIN_RPC_AUXPOW_MINER_H
+
+#include <miner.h>
+#include <script/script.h>
+#include <sync.h>
+#include <uint256.h>
+#include <univalue.h>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * This class holds "global" state used to construct blocks for the auxpow
+ * mining RPCs and the map of already constructed blocks to look them up
+ * in the submitauxblock RPC.
+ *
+ * It is used as a singleton that is initialised during startup, taking the
+ * place of the previously real global and static variables.
+ */
+class AuxpowMiner
+{
+
+private:
+
+  /** The lock used for state in this object.  */
+  mutable CCriticalSection cs;
+  /** All currently "active" block templates.  */
+  std::vector<std::unique_ptr<CBlockTemplate>> templates;
+  /** Maps block hashes to pointers in vTemplates.  Does not own the memory.  */
+  std::map<uint256, const CBlock*> blocks;
+
+  /**
+   * The block we are "currently" working on.  This does not own the memory,
+   * instead, it points into an element of templates.
+   */
+  CBlock* pblockCur = nullptr;
+  /** The current extra nonce for block creation.  */
+  unsigned extraNonce = 0;
+
+  /* Some data about when the current block (pblock) was constructed.  */
+  unsigned txUpdatedLast;
+  const CBlockIndex* pindexPrev = nullptr;
+  uint64_t startTime;
+
+  /**
+   * Constructs a new current block if necessary (checking the current state to
+   * see if "enough changed" for this), and returns a pointer to the block
+   * that should be returned to a miner for working on at the moment.  Also
+   * fills in the difficulty target value.
+   */
+  const CBlock* getCurrentBlock (const CScript& scriptPubKey, uint256& target);
+
+  /**
+   * Looks up a previously constructed block by its (hex-encoded) hash.  If the
+   * block is found, it is returned.  Otherwise, a JSONRPCError is thrown.
+   */
+  const CBlock* lookupSavedBlock (const std::string& hashHex) const;
+
+public:
+
+  AuxpowMiner () = default;
+
+  /**
+   * Performs the main work for the "createauxblock" RPC:  Construct a new block
+   * to work on with the given address for the block reward and return the
+   * necessary information for the miner to construct an auxpow for it.
+   */
+  UniValue createAuxBlock (const CScript& scriptPubKey);
+
+  /**
+   * Performs the main work for the "submitauxblock" RPC:  Look up the block
+   * previously created for the given hash, attach the given auxpow to it
+   * and try to submit it.  Returns true if all was successful and the block
+   * was accepted.
+   */
+  bool submitAuxBlock (const std::string& hashHex,
+                       const std::string& auxpowHex) const;
+
+};
+
+#endif // BITCOIN_RPC_AUXPOW_MINER_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -17,6 +17,7 @@
 #include <net.h>
 #include <policy/fees.h>
 #include <pow.h>
+#include <rpc/auxpow_miner.h>
 #include <rpc/blockchain.h>
 #include <rpc/mining.h>
 #include <rpc/server.h>
@@ -26,8 +27,8 @@
 #include <validationinterface.h>
 #include <warnings.h>
 
-#include <memory>
 #include <stdint.h>
+#include <string>
 #include <utility>
 
 unsigned int ParseConfirmTarget(const UniValue& value)
@@ -939,148 +940,7 @@ static UniValue estimaterawfee(const JSONRPCRequest& request)
 /* ************************************************************************** */
 /* Merge mining.  */
 
-namespace {
-
-/**
- * The variables below are used to keep track of created and not yet
- * submitted auxpow blocks.  Lock them to be sure even for multiple
- * RPC threads running in parallel.
- */
-CCriticalSection cs_auxblockCache;
-std::map<uint256, CBlock*> mapNewBlock;
-std::vector<std::unique_ptr<CBlockTemplate>> vNewBlockTemplate;
-
-void AuxMiningCheck()
-{
-  if(!g_connman)
-    throw JSONRPCError(RPC_CLIENT_P2P_DISABLED,
-                       "Error: Peer-to-peer functionality missing or disabled");
-
-  if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0
-        && !Params().MineBlocksOnDemand())
-    throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED,
-                       "Namecoin is not connected!");
-
-  if (IsInitialBlockDownload() && !Params().MineBlocksOnDemand())
-    throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                       "Namecoin is downloading blocks...");
-
-  /* This should never fail, since the chain is already
-     past the point of merge-mining start.  Check nevertheless.  */
-  {
-    LOCK(cs_main);
-    if (chainActive.Height() + 1 < Params().GetConsensus().nAuxpowStartHeight)
-      throw std::runtime_error("mining auxblock method is not yet available");
-  }
-}
-
-} // anonymous namespace
-
-UniValue AuxMiningCreateBlock(const CScript& scriptPubKey)
-{
-    AuxMiningCheck();
-
-    LOCK(cs_auxblockCache);
-
-    static unsigned nTransactionsUpdatedLast;
-    static const CBlockIndex* pindexPrev = nullptr;
-    static uint64_t nStart;
-    static CBlock* pblock = nullptr;
-    static unsigned nExtraNonce = 0;
-
-    // Update block
-    {
-    LOCK(cs_main);
-    if (pindexPrev != chainActive.Tip()
-        || (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast
-            && GetTime() - nStart > 60))
-    {
-        if (pindexPrev != chainActive.Tip())
-        {
-            // Clear old blocks since they're obsolete now.
-            mapNewBlock.clear();
-            vNewBlockTemplate.clear();
-            pblock = nullptr;
-        }
-
-        // Create new block with nonce = 0 and extraNonce = 1
-        std::unique_ptr<CBlockTemplate> newBlock
-            = BlockAssembler(Params()).CreateNewBlock(scriptPubKey);
-        if (!newBlock)
-            throw JSONRPCError(RPC_OUT_OF_MEMORY, "out of memory");
-
-        // Update state only when CreateNewBlock succeeded
-        nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-        pindexPrev = chainActive.Tip();
-        nStart = GetTime();
-
-        // Finalise it by setting the version and building the merkle root
-        IncrementExtraNonce(&newBlock->block, pindexPrev, nExtraNonce);
-        newBlock->block.SetAuxpowVersion(true);
-
-        // Save
-        pblock = &newBlock->block;
-        mapNewBlock[pblock->GetHash()] = pblock;
-        vNewBlockTemplate.push_back(std::move(newBlock));
-    }
-    }
-
-    // At this point, pblock is always initialised:  If we make it here
-    // without creating a new block above, it means that, in particular,
-    // pindexPrev == chainActive.Tip().  But for that to happen, we must
-    // already have created a pblock in a previous call, as pindexPrev is
-    // initialised only when pblock is.
-    assert(pblock);
-
-    arith_uint256 target;
-    bool fNegative, fOverflow;
-    target.SetCompact(pblock->nBits, &fNegative, &fOverflow);
-    if (fNegative || fOverflow || target == 0)
-        throw std::runtime_error("invalid difficulty bits in block");
-
-    UniValue result(UniValue::VOBJ);
-    result.pushKV("hash", pblock->GetHash().GetHex());
-    result.pushKV("chainid", pblock->GetChainId());
-    result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
-    result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("bits", strprintf("%08x", pblock->nBits));
-    result.pushKV("height", static_cast<int64_t> (pindexPrev->nHeight + 1));
-    result.pushKV("_target", HexStr(BEGIN(target), END(target)));
-
-    return result;
-}
-
-bool AuxMiningSubmitBlock(const std::string& hashHex,
-                          const std::string& auxpowHex)
-{
-    AuxMiningCheck();
-
-    LOCK(cs_auxblockCache);
-
-    uint256 hash;
-    hash.SetHex(hashHex);
-
-    const std::map<uint256, CBlock*>::iterator mit = mapNewBlock.find(hash);
-    if (mit == mapNewBlock.end())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "block hash unknown");
-    CBlock& block = *mit->second;
-
-    const std::vector<unsigned char> vchAuxPow = ParseHex(auxpowHex);
-    CDataStream ss(vchAuxPow, SER_GETHASH, PROTOCOL_VERSION);
-    CAuxPow pow;
-    ss >> pow;
-    block.SetAuxpow(new CAuxPow(pow));
-    assert(block.GetHash() == hash);
-
-    submitblock_StateCatcher sc(block.GetHash());
-    RegisterValidationInterface(&sc);
-    std::shared_ptr<const CBlock> shared_block 
-      = std::make_shared<const CBlock>(block);
-    bool fAccepted = ProcessNewBlock(Params(), shared_block, true, nullptr);
-    UnregisterValidationInterface(&sc);
-
-    return fAccepted;
-}
+std::unique_ptr<AuxpowMiner> g_auxpow_miner;
 
 UniValue createauxblock(const JSONRPCRequest& request)
 {
@@ -1114,7 +974,7 @@ UniValue createauxblock(const JSONRPCRequest& request)
     }
     const CScript scriptPubKey = GetScriptForDestination(coinbaseScript);
 
-    return AuxMiningCreateBlock(scriptPubKey);
+    return g_auxpow_miner->createAuxBlock(scriptPubKey);
 }
 
 UniValue submitauxblock(const JSONRPCRequest& request)
@@ -1133,10 +993,9 @@ UniValue submitauxblock(const JSONRPCRequest& request)
             + HelpExampleRpc("submitauxblock", "\"hash\" \"serialised auxpow\"")
             );
 
-    return AuxMiningSubmitBlock(request.params[0].get_str(), 
-                                request.params[1].get_str());
+    return g_auxpow_miner->submitAuxBlock(request.params[0].get_str(),
+                                          request.params[1].get_str());
 }
-
 
 /* ************************************************************************** */
 

--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -7,9 +7,11 @@
 
 #include <script/script.h>
 
-#include <string>
-
 #include <univalue.h>
+
+#include <memory>
+
+class AuxpowMiner;
 
 /** Generate blocks (mine) */
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript);
@@ -17,9 +19,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
 /** Check bounds on a command line confirm target */
 unsigned int ParseConfirmTarget(const UniValue& value);
 
-/* Creation and submission of auxpow blocks.  */
-UniValue AuxMiningCreateBlock(const CScript& scriptPubKey);
-bool AuxMiningSubmitBlock(const std::string& hashHex,
-                          const std::string& auxpowHex);
+/** Singleton instance of the AuxpowMiner, created during startup.  */
+extern std::unique_ptr<AuxpowMiner> g_auxpow_miner;
 
 #endif

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -2,18 +2,18 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "auxpow.h"
-#include "chainparams.h"
-#include "coins.h"
-#include "consensus/merkle.h"
-#include "validation.h"
-#include "pow.h"
-#include "primitives/block.h"
-#include "script/script.h"
-#include "utilstrencodings.h"
-#include "uint256.h"
+#include <auxpow.h>
+#include <chainparams.h>
+#include <coins.h>
+#include <consensus/merkle.h>
+#include <validation.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <script/script.h>
+#include <utilstrencodings.h>
+#include <uint256.h>
 
-#include "test/test_bitcoin.h"
+#include <test/test_bitcoin.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -15,6 +15,7 @@
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
+#include <rpc/auxpow_miner.h>
 #include <rpc/mining.h>
 #include <rpc/rawtransaction.h>
 #include <rpc/server.h>
@@ -4380,23 +4381,24 @@ UniValue getauxblock(const JSONRPCRequest& request)
     std::shared_ptr<CReserveScript> coinbaseScript;
     pwallet->GetScriptForMining(coinbaseScript);
 
-    // If the keypool is exhausted, no script is returned at all.  Catch this.
+    /* If the keypool is exhausted, no script is returned at all.
+       Catch this.  */
     if (!coinbaseScript)
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
 
-    //throw an error if no script was provided
+    /* Throw an error if no script was provided.  */
     if (!coinbaseScript->reserveScript.size())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
     /* Create a new block */
     if (request.params.size() == 0)
-        return AuxMiningCreateBlock(coinbaseScript->reserveScript);
+        return g_auxpow_miner->createAuxBlock(coinbaseScript->reserveScript);
 
-    /* Submit a block instead.  Note that this need not lock cs_main,
-       since ProcessNewBlock below locks it instead.  */
+    /* Submit a block instead.  */
     assert(request.params.size() == 2);
-    bool fAccepted = AuxMiningSubmitBlock(request.params[0].get_str(), 
-                                          request.params[1].get_str());
+    bool fAccepted
+        = g_auxpow_miner->submitAuxBlock(request.params[0].get_str(),
+                                         request.params[1].get_str());
     if (fAccepted)
         coinbaseScript->KeepScript();
 


### PR DESCRIPTION
This implements https://github.com/namecoin/namecoin-core/issues/224:  It creates a new `AuxpowMiner` class to hold the previously-global state and the logic of the merge-mining RPCs.  This separates the code better from the upstream `rpc/mining.cpp` code, and gets rid of all the global and in-function static variables.  Instead, there is now a clear construction and desctruction of the `AuxpowMiner` used during the startup and shutdown sequences.

By separating the code off, we can also add unit tests for the block (re)generation logic.