### PR TITLE
Handle name outputs in listunspent

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class CBlock;
+class CNameScript;
 class CScript;
 class CTransaction;
 struct CMutableTransaction;
@@ -32,5 +33,11 @@ std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+
+/**
+ * Converts a name script to an UniValue representation suitable to show
+ * for decoded transactions (and similar).
+ */
+UniValue NameOpToUniv(const CNameScript& nameOp);
 
 #endif // BITCOIN_CORE_IO_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -139,44 +139,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
 
     const CNameScript nameOp(scriptPubKey);
     if (nameOp.isNameOp ())
-    {
-        UniValue jsonOp(UniValue::VOBJ);
-        switch (nameOp.getNameOp ())
-        {
-        case OP_NAME_NEW:
-            jsonOp.pushKV ("op", "name_new");
-            jsonOp.pushKV ("hash", HexStr (nameOp.getOpHash ()));
-            break;
-
-        case OP_NAME_FIRSTUPDATE:
-        {
-            const std::string name = ValtypeToString (nameOp.getOpName ());
-            const std::string value = ValtypeToString (nameOp.getOpValue ());
-
-            jsonOp.pushKV ("op", "name_firstupdate");
-            jsonOp.pushKV ("name", name);
-            jsonOp.pushKV ("value", value);
-            jsonOp.pushKV ("rand", HexStr (nameOp.getOpRand ()));
-            break;
-        }
-
-        case OP_NAME_UPDATE:
-        {
-            const std::string name = ValtypeToString (nameOp.getOpName ());
-            const std::string value = ValtypeToString (nameOp.getOpValue ());
-
-            jsonOp.pushKV ("op", "name_update");
-            jsonOp.pushKV ("name", name);
-            jsonOp.pushKV ("value", value);
-            break;
-        }
-
-        default:
-            assert (false);
-        }
-
-        out.pushKV ("nameOp", jsonOp);
-    }
+        out.pushKV ("nameOp", NameOpToUniv (nameOp));
 
     out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
     if (fIncludeHex)
@@ -255,4 +218,46 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
     if (include_hex) {
         entry.pushKV("hex", EncodeHexTx(tx, serialize_flags)); // The hex-encoded transaction. Used the name "hex" to be consistent with the verbose output of "getrawtransaction".
     }
+}
+
+UniValue NameOpToUniv (const CNameScript& nameOp)
+{
+  assert (nameOp.isNameOp ());
+
+  UniValue result(UniValue::VOBJ);
+  switch (nameOp.getNameOp ())
+    {
+      case OP_NAME_NEW:
+        result.pushKV ("op", "name_new");
+        result.pushKV ("hash", HexStr (nameOp.getOpHash ()));
+        break;
+
+      case OP_NAME_FIRSTUPDATE:
+        {
+          const std::string name = ValtypeToString (nameOp.getOpName ());
+          const std::string value = ValtypeToString (nameOp.getOpValue ());
+
+          result.pushKV ("op", "name_firstupdate");
+          result.pushKV ("name", name);
+          result.pushKV ("value", value);
+          result.pushKV ("rand", HexStr (nameOp.getOpRand ()));
+          break;
+        }
+
+      case OP_NAME_UPDATE:
+        {
+          const std::string name = ValtypeToString (nameOp.getOpName ());
+          const std::string value = ValtypeToString (nameOp.getOpValue ());
+
+          result.pushKV ("op", "name_update");
+          result.pushKV ("name", name);
+          result.pushKV ("value", value);
+          break;
+        }
+
+      default:
+        assert (false);
+    }
+
+  return result;
 }

--- a/test/functional/name_listunspent.py
+++ b/test/functional/name_listunspent.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for correct handling of names in "listunspent".
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameListUnspentTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 2)
+
+  def lookupName (self, ind, name, **kwargs):
+    """Wrapper around lookup that gets txid and vout from the name."""
+
+    pending = self.nodes[ind].name_pending (name)
+    if len (pending) > 0:
+      data = pending[0]
+    else:
+      data = self.nodes[ind].name_show (name)
+
+    return self.lookup (ind, data['txid'], data['vout'], **kwargs)
+
+  def lookup (self, ind, txid, vout,
+              addressFilter=None,
+              allowUnconfirmed=False,
+              includeNames=False):
+    """
+    Runs listunspent on the given node and returns the unspent result matching
+    the txid:vout combination or None.
+    """
+
+    minConf = 1
+    if allowUnconfirmed:
+      minConf = 0
+
+    opt = {"includeNames": includeNames}
+    res = self.nodes[ind].listunspent (minConf, None, addressFilter, None, opt)
+
+    for out in res:
+      if (out['txid'], out['vout']) == (txid, vout):
+        return out
+    return None
+
+  def run_test (self):
+
+    # Create a name new for testing.  Figure out the vout by looking at the
+    # raw transaction.
+    addrA = self.nodes[0].getnewaddress ()
+    new = self.nodes[0].name_new ("testname", {"destAddress": addrA})
+    txid = new[0]
+    raw = self.nodes[0].getrawtransaction (txid, 1)
+    vout = None
+    for i in range (len (raw['vout'])):
+      if 'nameOp' in raw['vout'][i]['scriptPubKey']:
+        vout = i
+        break
+    assert vout is not None
+
+    # Check expected behaviour for listunspent with the unconfirmed name_new.
+    assert self.lookup (0, txid, vout, allowUnconfirmed=True) is None
+    assert self.lookup (0, txid, vout, includeNames=True) is None
+    unspent = self.lookup (0, txid, vout,
+                           addressFilter=[addrA],
+                           allowUnconfirmed=True,
+                           includeNames=True)
+    assert unspent is not None
+    assert_equal (unspent['confirmations'], 0)
+    assert 'nameOp' in unspent
+    assert_equal (unspent['nameOp']['op'], 'name_new')
+
+    # Name new's don't expire.  Verify that we get it after confirmation
+    # correctly as well.
+    self.nodes[0].generate (50)
+    unspent = self.lookup (0, txid, vout, includeNames=True)
+    assert unspent is not None
+    assert_equal (unspent['confirmations'], 50)
+    assert 'nameOp' in unspent
+
+    # Firstupdate the name and check that briefly.
+    self.firstupdateName (0, "testname", new, "value")
+    self.nodes[0].generate (1)
+    unspent = self.lookupName (0, "testname", includeNames=True)
+    assert unspent is not None
+    assert 'nameOp' in unspent
+    assert_equal (unspent['nameOp']['op'], 'name_firstupdate')
+    assert_equal (unspent['nameOp']['name'], 'testname')
+
+    # Update the name, sending to another node.
+    addrB = self.nodes[1].getnewaddress ()
+    self.nodes[0].name_update ("testname", "value", {"destAddress": addrB})
+    sync_mempools (self.nodes)
+
+    # Node 0 should no longer have the unspent output.
+    assert self.lookupName (0, "testname",
+                            allowUnconfirmed=True,
+                            includeNames=True) is None
+    assert self.lookupName (0, "testname",
+                            allowUnconfirmed=True,
+                            includeNames=True) is None
+
+    # Node 1 should now see the output as unconfirmed.
+    assert self.lookupName (1, "testname", allowUnconfirmed=True) is None
+    assert self.lookupName (1, "testname", includeNames=True) is None
+    unspent = self.lookupName (1, "testname",
+                               addressFilter=[addrB],
+                               allowUnconfirmed=True,
+                               includeNames=True)
+    assert unspent is not None
+    assert_equal (unspent['confirmations'], 0)
+    assert 'nameOp' in unspent
+    assert_equal (unspent['nameOp']['op'], 'name_update')
+    assert_equal (unspent['nameOp']['name'], 'testname')
+
+    # Mine blocks and verify node 1 seeing the name correctly.
+    self.nodes[1].generate (30)
+    assert_equal (self.nodes[1].name_show ("testname")['expired'], False)
+    assert_equal (self.nodes[1].name_show ("testname")['expires_in'], 1)
+    assert self.lookupName (1, "testname") is None
+    assert self.lookupName (1, "testname",
+                            addressFilter=[addrA],
+                            includeNames=True) is None
+    unspent = self.lookupName (1, "testname", includeNames=True)
+    assert unspent is not None
+    assert_equal (unspent['confirmations'], 30)
+    assert 'nameOp' in unspent
+    assert_equal (unspent['nameOp']['op'], 'name_update')
+    assert_equal (unspent['nameOp']['name'], 'testname')
+
+    # One more block and the name expires.  Then it should no longer show up.
+    self.nodes[1].generate (1)
+    assert_equal (self.nodes[1].name_show ("testname")['expired'], True)
+    assert self.lookupName (1, "testname", includeNames=True) is None
+
+if __name__ == '__main__':
+  NameListUnspentTest ().main ()

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -6,6 +6,9 @@ echo "\nName expiration..."
 echo "\nName list..."
 ./name_list.py
 
+echo "\nName listunspent..."
+./name_listunspent.py
+
 echo "\nName multisig..."
 ./name_multisig.py
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -160,6 +160,7 @@ BASE_SCRIPTS = [
     # name tests
     'name_expiration.py',
     'name_list.py',
+    'name_listunspent.py',
     'name_multisig.py',
     'name_pending.py',
     'name_rawtx.py',


### PR DESCRIPTION
Previously, `listunspent` did not explicitly handle name outputs - and as a consequence, they were just shown mixed in with (and undistinguishable from) the currency outputs.  This adds explicit handling:

* Any *expired* name outputs are always excluded, as they are unspendable.
* Other name outputs are included in the results only if the new `includeNames` RPC option, which is off by default, is set.
* If name outputs are included in the result, then they are marked by a `nameOp` field equivalent to that of `decoderawtransaction`.

This implements https://github.com/namecoin/namecoin-core/issues/192.