### PR TITLE
Clean up auxpow code

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -12,6 +12,7 @@
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <hash.h>
+#include <primitives/block.h>
 #include <script/script.h>
 #include <txmempool.h>
 #include <util.h>

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -68,7 +68,7 @@ bool
 CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
                 const Consensus::Params& params) const
 {
-    if (nIndex != 0)
+    if (coinbaseTx.nIndex != 0)
         return error("AuxPow is not a generate");
 
     if (params.fStrictChainId && parentBlock.GetChainId () == nChainId)
@@ -84,11 +84,12 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
     std::reverse (vchRootHash.begin (), vchRootHash.end ()); // correct endian
 
     // Check that we are in the parent block merkle tree
-    if (CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex)
+    if (CheckMerkleBranch(coinbaseTx.GetHash(), coinbaseTx.vMerkleBranch,
+                          coinbaseTx.nIndex)
           != parentBlock.hashMerkleRoot)
         return error("Aux POW merkle root incorrect");
 
-    const CScript script = tx->vin[0].scriptSig;
+    const CScript script = coinbaseTx.tx->vin[0].scriptSig;
 
     // Check that the same work is not submitted twice to our chain.
     //
@@ -220,8 +221,8 @@ CAuxPow::createAuxPow (const CPureBlockHeader& header)
   std::unique_ptr<CAuxPow> auxpow(new CAuxPow (coinbaseRef));
   assert (auxpow->vChainMerkleBranch.empty ());
   auxpow->nChainIndex = 0;
-  assert (auxpow->vMerkleBranch.empty ());
-  auxpow->nIndex = 0;
+  assert (auxpow->coinbaseTx.vMerkleBranch.empty ());
+  auxpow->coinbaseTx.nIndex = 0;
   auxpow->parentBlock = parent;
 
   return auxpow;

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -10,59 +10,14 @@
 #include <compat/endian.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
-#include <consensus/validation.h>
 #include <hash.h>
 #include <primitives/block.h>
 #include <script/script.h>
-#include <txmempool.h>
 #include <util.h>
 #include <utilstrencodings.h>
-#include <validation.h>
 
 #include <algorithm>
 #include <cassert>
-
-/* Moved from wallet.cpp.  CMerkleTx is necessary for auxpow, independent
-   of an enabled (or disabled) wallet.  Always include the code.  */
-
-const uint256 CMerkleTx::ABANDON_HASH(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-
-void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
-{
-    // Update the tx's hashBlock
-    hashBlock = pindex->GetBlockHash();
-
-    // set the position of the transaction in the block
-    nIndex = posInBlock;
-}
-
-int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
-{
-    if (hashUnset())
-        return 0;
-
-    AssertLockHeld(cs_main);
-
-    // Find the block it claims to be in
-    BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
-    if (mi == mapBlockIndex.end())
-        return 0;
-    CBlockIndex* pindex = (*mi).second;
-    if (!pindex || !chainActive.Contains(pindex))
-        return 0;
-
-    pindexRet = pindex;
-    return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - pindex->nHeight + 1);
-}
-
-int CMerkleTx::GetBlocksToMaturity() const
-{
-    if (!IsCoinBase())
-        return 0;
-    return std::max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
-}
-
-/* ************************************************************************** */
 
 bool
 CAuxPow::check (const uint256& hashAuxBlock, int nChainId,

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -13,6 +13,7 @@
 #include <serialize.h>
 #include <uint256.h>
 
+#include <memory>
 #include <vector>
 
 class CBlock;
@@ -162,18 +163,13 @@ public:
   bool check (const uint256& hashAuxBlock, int nChainId,
               const Consensus::Params& params) const;
 
-  /* Accessors for the parent block.  */
-
-  inline CPureBlockHeader&
-  getParentBlock ()
+  /**
+   * Returns the parent block hash.  This is used to validate the PoW.
+   */
+  inline uint256
+  getParentBlockHash () const
   {
-    return parentBlock;
-  }
-
-  inline const CPureBlockHeader&
-  getParentBlock () const
-  {
-    return parentBlock;
+    return parentBlock.GetHash ();
   }
 
   /**
@@ -195,13 +191,19 @@ public:
                                     int nIndex);
 
   /**
-   * Initialise the auxpow of the given block header.  This constructs
-   * a minimal CAuxPow object with a minimal parent block and sets
-   * it on the block header.  The auxpow is not necessarily valid, but
-   * can be "mined" to make it valid.
-   * @param header The header to set the auxpow on.
+   * Constructs a minimal CAuxPow object for the given block header and
+   * returns it.  The caller should make sure to set the auxpow flag on the
+   * header already, since the block hash to which the auxpow commits depends
+   * on that!
    */
-  static void initAuxPow (CBlockHeader& header);
+  static std::unique_ptr<CAuxPow> createAuxPow (const CPureBlockHeader& header);
+
+  /**
+   * Initialises the auxpow of the given block header.  This builds a minimal
+   * auxpow object like createAuxPow and sets it on the block header.  Returns
+   * a reference to the parent header so it can be mined as a follow-up.
+   */
+  static CPureBlockHeader& initAuxPow (CBlockHeader& header);
 
 };
 

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -130,6 +130,14 @@ private:
   /** Parent block header (on which the real PoW is done).  */
   CPureBlockHeader parentBlock;
 
+  /**
+   * Check a merkle branch.  This used to be in CBlock, but was removed
+   * upstream.  Thus include it here now.
+   */
+  static uint256 CheckMerkleBranch (uint256 hash,
+                                    const std::vector<uint256>& vMerkleBranch,
+                                    int nIndex);
+
   friend UniValue AuxpowToJSON(const CAuxPow& auxpow);
   friend class auxpow_tests::CAuxPowForTest;
 
@@ -184,14 +192,6 @@ public:
    * @return The expected index for the aux hash.
    */
   static int getExpectedIndex (uint32_t nNonce, int nChainId, unsigned h);
-
-  /**
-   * Check a merkle branch.  This used to be in CBlock, but was removed
-   * upstream.  Thus include it here now.
-   */
-  static uint256 CheckMerkleBranch (uint256 hash,
-                                    const std::vector<uint256>& vMerkleBranch,
-                                    int nIndex);
 
   /**
    * Constructs a minimal CAuxPow object for the given block header and

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -106,15 +106,20 @@ public:
 };
 
 /**
- * Data for the merge-mining auxpow.  This is a merkle tx (the parent block's
- * coinbase tx) that can be verified to be in the parent block, and this
- * transaction's input (the coinbase script) contains the reference
- * to the actual merge-mined block.
+ * Data for the merge-mining auxpow.  This uses a merkle tx (the parent block's
+ * coinbase tx) and a manual merkle branch to link the actual Namecoin block
+ * header to the parent block header, which is mined to satisfy the PoW.
  */
-class CAuxPow : public CMerkleTx
+class CAuxPow
 {
 
 private:
+
+  /**
+   * The parent block's coinbase tx, which is used to link the auxpow from
+   * the tx input to the parent block header.
+   */
+  CMerkleTx coinbaseTx;
 
   /** The merkle branch connecting the aux block to our coinbase.  */
   std::vector<uint256> vChainMerkleBranch;
@@ -132,12 +137,10 @@ public:
 
   /* Prevent accidental conversion.  */
   inline explicit CAuxPow (CTransactionRef txIn)
-    : CMerkleTx (txIn)
+    : coinbaseTx (txIn)
   {}
 
-  inline CAuxPow ()
-    : CMerkleTx ()
-  {}
+  CAuxPow () = default;
 
   ADD_SERIALIZE_METHODS;
 
@@ -145,7 +148,7 @@ public:
     inline void
     SerializationOp (Stream& s, Operation ser_action)
   {
-    READWRITE (*static_cast<CMerkleTx*> (this));
+    READWRITE (coinbaseTx);
     READWRITE (vChainMerkleBranch);
     READWRITE (nChainIndex);
     READWRITE (parentBlock);

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -19,6 +19,12 @@ class CBlock;
 class CBlockHeader;
 class CBlockIndex;
 class CValidationState;
+class UniValue;
+
+namespace auxpow_tests
+{
+class CAuxPowForTest;
+}
 
 /** Header for merge-mining data in the coinbase.  */
 static const unsigned char pchMergedMiningHeader[] = { 0xfa, 0xbe, 'm', 'm' };
@@ -107,8 +113,7 @@ public:
 class CAuxPow : public CMerkleTx
 {
 
-/* Public for the unit tests.  */
-public:
+private:
 
   /** The merkle branch connecting the aux block to our coinbase.  */
   std::vector<uint256> vChainMerkleBranch;
@@ -118,6 +123,9 @@ public:
 
   /** Parent block header (on which the real PoW is done).  */
   CPureBlockHeader parentBlock;
+
+  friend UniValue AuxpowToJSON(const CAuxPow& auxpow);
+  friend class auxpow_tests::CAuxPowForTest;
 
 public:
 
@@ -154,15 +162,18 @@ public:
   bool check (const uint256& hashAuxBlock, int nChainId,
               const Consensus::Params& params) const;
 
-  /**
-   * Get the parent block's hash.  This is used to verify that it
-   * satisfies the PoW requirement.
-   * @return The parent block hash.
-   */
-  inline uint256
-  getParentBlockHash () const
+  /* Accessors for the parent block.  */
+
+  inline CPureBlockHeader&
+  getParentBlock ()
   {
-    return parentBlock.GetHash ();
+    return parentBlock;
+  }
+
+  inline const CPureBlockHeader&
+  getParentBlock () const
+  {
+    return parentBlock;
   }
 
   /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -76,8 +76,6 @@ double GetDifficulty(const CBlockIndex* blockindex)
     return dDiff;
 }
 
-namespace
-{
 UniValue AuxpowToJSON(const CAuxPow& auxpow)
 {
     UniValue result(UniValue::VOBJ);
@@ -113,7 +111,6 @@ UniValue AuxpowToJSON(const CAuxPow& auxpow)
 
     return result;
 }
-} // anonymous namespace
 
 UniValue blockheaderToJSON(const CBlockIndex* blockindex)
 {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -82,17 +82,17 @@ UniValue AuxpowToJSON(const CAuxPow& auxpow)
 
     {
         UniValue tx(UniValue::VOBJ);
-        tx.push_back(Pair("hex", EncodeHexTx(*auxpow.tx)));
-        TxToJSON(*auxpow.tx, auxpow.parentBlock.GetHash(), tx);
+        tx.push_back(Pair("hex", EncodeHexTx(*auxpow.coinbaseTx.tx)));
+        TxToJSON(*auxpow.coinbaseTx.tx, auxpow.parentBlock.GetHash(), tx);
         result.push_back(Pair("tx", tx));
     }
 
-    result.push_back(Pair("index", auxpow.nIndex));
+    result.push_back(Pair("index", auxpow.coinbaseTx.nIndex));
     result.push_back(Pair("chainindex", auxpow.nChainIndex));
 
     {
         UniValue branch(UniValue::VARR);
-        for (const auto& node : auxpow.vMerkleBranch)
+        for (const auto& node : auxpow.coinbaseTx.vMerkleBranch)
             branch.push_back(node.GetHex());
         result.push_back(Pair("merklebranch", branch));
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -128,8 +128,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
-        CAuxPow::initAuxPow(*pblock);
-        CPureBlockHeader& miningHeader = pblock->auxpow->getParentBlock();
+        auto& miningHeader = CAuxPow::initAuxPow(*pblock);
         while (nMaxTries > 0 && miningHeader.nNonce < nInnerLoopCount && !CheckProofOfWork(miningHeader.GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++miningHeader.nNonce;
             --nMaxTries;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -129,7 +129,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
         CAuxPow::initAuxPow(*pblock);
-        CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
+        CPureBlockHeader& miningHeader = pblock->auxpow->getParentBlock();
         while (nMaxTries > 0 && miningHeader.nNonce < nInnerLoopCount && !CheckProofOfWork(miningHeader.GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++miningHeader.nNonce;
             --nMaxTries;

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -43,6 +43,25 @@ tamperWith (uint256& num)
 }
 
 /**
+ * Helper class that is friend to CAuxPow and makes the internals accessible
+ * to the test code.
+ */
+class CAuxPowForTest : public CAuxPow
+{
+
+public:
+
+  explicit inline CAuxPowForTest (CTransactionRef txIn)
+    : CAuxPow (txIn)
+  {}
+
+  using CAuxPow::vChainMerkleBranch;
+  using CAuxPow::nChainIndex;
+  using CAuxPow::parentBlock;
+
+};
+
+/**
  * Utility class to construct auxpow's and manipulate them.  This is used
  * to simulate various scenarios.
  */
@@ -171,7 +190,7 @@ CAuxpowBuilder::get (const CTransactionRef tx) const
 {
   LOCK(cs_main);
 
-  CAuxPow res(tx);
+  CAuxPowForTest res(tx);
   res.hashBlock = parentBlock.GetHash ();
   res.nIndex = 0;
   res.vMerkleBranch = merkle_tests::BlockMerkleBranch (parentBlock, res.nIndex);

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -55,6 +55,7 @@ public:
     : CAuxPow (txIn)
   {}
 
+  using CAuxPow::coinbaseTx;
   using CAuxPow::vChainMerkleBranch;
   using CAuxPow::nChainIndex;
   using CAuxPow::parentBlock;
@@ -191,9 +192,10 @@ CAuxpowBuilder::get (const CTransactionRef tx) const
   LOCK(cs_main);
 
   CAuxPowForTest res(tx);
-  res.hashBlock = parentBlock.GetHash ();
-  res.nIndex = 0;
-  res.vMerkleBranch = merkle_tests::BlockMerkleBranch (parentBlock, res.nIndex);
+  res.coinbaseTx.hashBlock = parentBlock.GetHash ();
+  res.coinbaseTx.nIndex = 0;
+  res.coinbaseTx.vMerkleBranch
+      = merkle_tests::BlockMerkleBranch (parentBlock, res.coinbaseTx.nIndex);
 
   res.vChainMerkleBranch = auxpowChainMerkleBranch;
   res.nChainIndex = auxpowChainIndex;

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -60,6 +60,8 @@ public:
   using CAuxPow::nChainIndex;
   using CAuxPow::parentBlock;
 
+  using CAuxPow::CheckMerkleBranch;
+
 };
 
 /**
@@ -178,7 +180,8 @@ CAuxpowBuilder::buildAuxpowChain (const uint256& hashAux, unsigned h, int index)
     auxpowChainMerkleBranch.push_back (ArithToUint256 (arith_uint256 (i)));
 
   const uint256 hash
-    = CAuxPow::CheckMerkleBranch (hashAux, auxpowChainMerkleBranch, index);
+    = CAuxPowForTest::CheckMerkleBranch (hashAux, auxpowChainMerkleBranch,
+                                         index);
 
   valtype res = ToByteVector (hash);
   std::reverse (res.begin (), res.end ());

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -72,9 +72,7 @@ std::shared_ptr<CBlock> FinalizeBlock(std::shared_ptr<CBlock> pblock)
 {
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 
-    CAuxPow::initAuxPow(*pblock);
-    CPureBlockHeader& miningHeader = pblock->auxpow->getParentBlock();
-
+    auto& miningHeader = CAuxPow::initAuxPow(*pblock);
     while (!CheckProofOfWork(miningHeader.GetHash(), pblock->nBits, Params().GetConsensus())) {
         ++(miningHeader.nNonce);
     }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<CBlock> FinalizeBlock(std::shared_ptr<CBlock> pblock)
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 
     CAuxPow::initAuxPow(*pblock);
-    CPureBlockHeader& miningHeader = pblock->auxpow->parentBlock;
+    CPureBlockHeader& miningHeader = pblock->auxpow->getParentBlock();
 
     while (!CheckProofOfWork(miningHeader.GetHash(), pblock->nBits, Params().GetConsensus())) {
         ++(miningHeader.nNonce);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1103,7 +1103,7 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
 
     if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
-    if (!CheckProofOfWork(block.auxpow->getParentBlock().GetHash(), block.nBits, params))
+    if (!CheckProofOfWork(block.auxpow->getParentBlockHash(), block.nBits, params))
         return error("%s : AUX proof of work failed", __func__);
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1103,7 +1103,7 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
 
     if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
-    if (!CheckProofOfWork(block.auxpow->getParentBlockHash(), block.nBits, params))
+    if (!CheckProofOfWork(block.auxpow->getParentBlock().GetHash(), block.nBits, params))
         return error("%s : AUX proof of work failed", __func__);
 
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -90,6 +90,8 @@ static void ReleaseWallet(CWallet* wallet)
 
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 
+const uint256 CMerkleTx::ABANDON_HASH(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+
 /** @defgroup mapWallet
  *
  * @{
@@ -4403,6 +4405,41 @@ CWalletKey::CWalletKey(int64_t nExpires)
 {
     nTimeCreated = (nExpires ? GetTime() : 0);
     nTimeExpires = nExpires;
+}
+
+void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
+{
+    // Update the tx's hashBlock
+    hashBlock = pindex->GetBlockHash();
+
+    // set the position of the transaction in the block
+    nIndex = posInBlock;
+}
+
+int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
+{
+    if (hashUnset())
+        return 0;
+
+    AssertLockHeld(cs_main);
+
+    // Find the block it claims to be in
+    BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
+    if (mi == mapBlockIndex.end())
+        return 0;
+    CBlockIndex* pindex = (*mi).second;
+    if (!pindex || !chainActive.Contains(pindex))
+        return 0;
+
+    pindexRet = pindex;
+    return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - pindex->nHeight + 1);
+}
+
+int CMerkleTx::GetBlocksToMaturity() const
+{
+    if (!IsCoinBase())
+        return 0;
+    return std::max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
 }
 
 bool CWalletTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,7 +7,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <amount.h>
-#include <auxpow.h> // contains CMerkleTx
+#include <auxpow.h> // contains CBaseMerkleTx
 #include <policy/feerate.h>
 #include <streams.h>
 #include <tinyformat.h>
@@ -206,6 +206,40 @@ struct COutputEntry
     CTxDestination destination;
     CAmount amount;
     int vout;
+};
+
+/** A transaction with a merkle branch linking it to the block chain. */
+class CMerkleTx : public CBaseMerkleTx
+{
+private:
+  /** Constant used in hashBlock to indicate tx has been abandoned */
+    static const uint256 ABANDON_HASH;
+
+public:
+
+    CMerkleTx() = default;
+
+    explicit CMerkleTx(CTransactionRef arg)
+      : CBaseMerkleTx(arg)
+    {}
+
+    void SetMerkleBranch(const CBlockIndex* pindex, int posInBlock);
+
+    /**
+     * Return depth of transaction in blockchain:
+     * <0  : conflicts with a transaction this deep in the blockchain
+     *  0  : in memory pool, waiting to be included in a block
+     * >=1 : this many blocks deep in the main chain
+     */
+    int GetDepthInMainChain(const CBlockIndex* &pindexRet) const;
+    int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
+    bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
+    int GetBlocksToMaturity() const;
+    bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
+    bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
+    void setAbandoned() { hashBlock = ABANDON_HASH; }
+
+    bool IsCoinBase() const { return tx->IsCoinBase(); }
 };
 
 //Get the marginal bytes of spending the specified output


### PR DESCRIPTION
This is a collection of code cleanups for the `CAuxPow`-related code.  Some internals are made private to enforce better encapsulation, and the dependency-issue of `CMerkleTx` described in #231 is fixed by introducing a `CBaseMerkleTx` class.