### PR TITLE
Consistently add "ismine" field to all name RPCs

### DIFF
--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -205,8 +205,8 @@ extern std::string HelpExampleCli(const std::string& methodname, const std::stri
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
 
 extern UniValue getNameInfo(const valtype& name, const valtype& value, const COutPoint& outp, const CScript& addr);
-extern void addExpirationInfo(int height, UniValue& data);
 extern UniValue getNameInfo(const valtype& name, const CNameData& data);
+extern void addExpirationInfo(int height, UniValue& data);
 
 #ifdef ENABLE_WALLET
 class CWallet;
@@ -234,7 +234,6 @@ public:
 
   NameInfoHelp& withField (const std::string& field, const std::string& doc);
   NameInfoHelp& withExpiration ();
-  NameInfoHelp& withOwnership ();
 
   std::string finish (const std::string& trailing);
 };

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -208,6 +208,13 @@ extern UniValue getNameInfo(const valtype& name, const valtype& value, const COu
 extern void addExpirationInfo(int height, UniValue& data);
 extern UniValue getNameInfo(const valtype& name, const CNameData& data);
 
+#ifdef ENABLE_WALLET
+class CWallet;
+extern void addOwnershipInfo(const CScript& addr,
+                             const CWallet* pwallet,
+                             UniValue& data);
+#endif
+
 /**
  * Builder class for the help text of RPCs that return information about
  * names (like name_show, name_scan, name_pending or name_list).  Since the
@@ -227,6 +234,7 @@ public:
 
   NameInfoHelp& withField (const std::string& field, const std::string& doc);
   NameInfoHelp& withExpiration ();
+  NameInfoHelp& withOwnership ();
 
   std::string finish (const std::string& trailing);
 };

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -246,7 +246,6 @@ name_list (const JSONRPCRequest& request)
         "[\n"
         + NameInfoHelp ("  ")
             .withExpiration ()
-            .withOwnership ()
             .finish (",") +
         "  ...\n"
         "]\n"
@@ -311,8 +310,8 @@ name_list (const JSONRPCRequest& request)
         = getNameInfo (name, nameOp.getOpValue (),
                        COutPoint (tx.GetHash (), nOut),
                        nameOp.getAddress ());
-      addExpirationInfo (pindex->nHeight, obj);
       addOwnershipInfo (nameOp.getAddress (), pwallet, obj);
+      addExpirationInfo (pindex->nHeight, obj);
 
       mapHeights[name] = pindex->nHeight;
       mapObjects[name] = obj;

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -246,9 +246,7 @@ name_list (const JSONRPCRequest& request)
         "[\n"
         + NameInfoHelp ("  ")
             .withExpiration ()
-            .withField ("\"transferred\": xxxxx",
-                        "(boolean) whether the name was transferred and is"
-                        " no longer owned by the wallet")
+            .withOwnership ()
             .finish (",") +
         "  ...\n"
         "]\n"
@@ -305,7 +303,7 @@ name_list (const JSONRPCRequest& request)
       if (depth <= 0)
         continue;
 
-      const std::map<valtype, int>::const_iterator mit = mapHeights.find (name);
+      const auto mit = mapHeights.find (name);
       if (mit != mapHeights.end () && mit->second > pindex->nHeight)
         continue;
 
@@ -314,9 +312,7 @@ name_list (const JSONRPCRequest& request)
                        COutPoint (tx.GetHash (), nOut),
                        nameOp.getAddress ());
       addExpirationInfo (pindex->nHeight, obj);
-
-      const bool mine = IsMine (*pwallet, nameOp.getAddress ());
-      obj.pushKV ("transferred", !mine);
+      addOwnershipInfo (nameOp.getAddress (), pwallet, obj);
 
       mapHeights[name] = pindex->nHeight;
       mapObjects[name] = obj;

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -321,6 +321,10 @@ class RESTTest (BitcoinTestFramework):
         nameData = self.nodes[0].name_show(name)
         assert_equal(nameData['name'], name)
         assert_equal(nameData['value'], value)
+        # The REST interface explicitly does not include the 'ismine' field
+        # that the RPC interface has.  Thus remove the field for the comparison
+        # below.
+        del nameData['ismine']
 
         # Different variants of the encoded name that should all work.
         variants = [urllib.parse.quote_plus(name), "d/some+weird.name%2b%2B"]

--- a/test/functional/name_ismine.py
+++ b/test/functional/name_ismine.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for the "ismine" field in the various name RPCs.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameIsMineTest (NameTestFramework):
+
+  def set_test_params (self):
+    # We only use node 1 for the test, but need that (and not node 0) because
+    # it has -namehistory set in the cached chain.
+    self.setup_name_test ([[], ['-namehistory']])
+
+  def verifyExpectedIsMineInList (self, arr):
+    """
+    Goes through the array of name info, as returned by name_scan or name_list.
+    It verifies that exactly the two expected names are there, and the
+    ismine field matches the expectation for them.
+    """
+
+    assert_equal (len (arr), 2)
+
+    for n in arr:
+      if n['name'] == "d/a":
+        assert_equal (n['ismine'], True)
+      elif n['name'] == "d/b":
+        assert_equal (n['ismine'], False)
+      else:
+        raise AssertionError ("Unexpected name in array: %s" % n['name'])
+
+  def run_test (self):
+    self.node = self.nodes[1]
+
+    # Register two names.  One of them is then sent to an address not owned
+    # by the node and one is updated into a pending operation.  That then
+    # gives us the basic setup to test the "ismine" field in all the
+    # circumstances.
+    newA = self.node.name_new ("d/a")
+    newB = self.node.name_new ("d/b")
+    self.node.generate (10)
+    self.firstupdateName (1, "d/a", newA, "value")
+    self.firstupdateName (1, "d/b", newB, "value")
+    self.node.generate (5)
+    otherAddr = self.nodes[0].getnewaddress ()
+    self.node.name_update ("d/b", "new value", {"destAddress": otherAddr})
+    self.node.generate (1)
+    self.node.name_update ("d/a", "new value")
+
+    # name_show
+    assert_equal (self.node.name_show ("d/a")['ismine'], True)
+    assert_equal (self.node.name_show ("d/b")['ismine'], False)
+
+    # name_history
+    hist = self.node.name_history ("d/a")
+    assert_equal (len (hist), 1)
+    assert_equal (hist[0]['ismine'], True)
+    hist = self.node.name_history ("d/b")
+    assert_equal (len (hist), 2)
+    assert_equal (hist[0]['ismine'], True)
+    assert_equal (hist[1]['ismine'], False)
+
+    # name_pending
+    pending = self.node.name_pending ()
+    assert_equal (len (pending), 1)
+    p = pending[0]
+    assert_equal (p['name'], "d/a")
+    assert_equal (p['ismine'], True)
+
+    # name_scan, name_filter, name_list
+    self.verifyExpectedIsMineInList (self.node.name_scan ())
+    self.verifyExpectedIsMineInList (self.node.name_filter ())
+    self.verifyExpectedIsMineInList (self.node.name_list ())
+
+if __name__ == '__main__':
+  NameIsMineTest ().main ()

--- a/test/functional/name_list.py
+++ b/test/functional/name_list.py
@@ -26,10 +26,10 @@ class NameListTest (NameTestFramework):
 
     arr = self.nodes[0].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "value-a", False, False)
+    self.checkNameStatus (arr[0], "name-a", "value-a", False, True)
     arr = self.nodes[1].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-b", "value-b", False, False)
+    self.checkNameStatus (arr[0], "name-b", "value-b", False, True)
 
     assert_equal (self.nodes[0].name_list ("name-b"), [])
     assert_equal (self.nodes[1].name_list ("name-a"), [])
@@ -40,16 +40,16 @@ class NameListTest (NameTestFramework):
     self.nodes[0].name_update ("name-a", "enjoy", {"destAddress":addrB})
     arr = self.nodes[0].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "value-a", False, False)
+    self.checkNameStatus (arr[0], "name-a", "value-a", False, True)
 
     self.generate (0, 1)
     arr = self.nodes[0].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "enjoy", False, True)
+    self.checkNameStatus (arr[0], "name-a", "enjoy", False, False)
     arr = self.nodes[1].name_list ()
     assert_equal (len (arr), 2)
-    self.checkNameStatus (arr[0], "name-a", "enjoy", False, False)
-    self.checkNameStatus (arr[1], "name-b", "value-b", False, False)
+    self.checkNameStatus (arr[0], "name-a", "enjoy", False, True)
+    self.checkNameStatus (arr[1], "name-b", "value-b", False, True)
 
     # Updating the name in the new wallet shouldn't change the
     # old wallet's name_list entry.
@@ -57,10 +57,10 @@ class NameListTest (NameTestFramework):
     self.generate (0, 1)
     arr = self.nodes[0].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "enjoy", False, True)
+    self.checkNameStatus (arr[0], "name-a", "enjoy", False, False)
     arr = self.nodes[1].name_list ("name-a")
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "new value", False, False)
+    self.checkNameStatus (arr[0], "name-a", "new value", False, True)
 
     # Transfer it back and see that it updates in wallet A.
     addrA = self.nodes[0].getnewaddress ()
@@ -68,22 +68,22 @@ class NameListTest (NameTestFramework):
     self.generate (0, 1)
     arr = self.nodes[0].name_list ()
     assert_equal (len (arr), 1)
-    self.checkNameStatus (arr[0], "name-a", "sent", False, False)
+    self.checkNameStatus (arr[0], "name-a", "sent", False, True)
 
     # Let name-b expire.
     self.generate (0, 25)
     arr = self.nodes[1].name_list ()
     assert_equal (len (arr), 2)
-    self.checkNameStatus (arr[0], "name-a", "sent", False, True)
-    self.checkNameStatus (arr[1], "name-b", "value-b", True, False)
+    self.checkNameStatus (arr[0], "name-a", "sent", False, False)
+    self.checkNameStatus (arr[1], "name-b", "value-b", True, True)
 
-  def checkNameStatus (self, data, name, value, expired, transferred):
+  def checkNameStatus (self, data, name, value, expired, mine):
     """
     Check a name_list entry for the expected data.
     """
 
     self.checkNameData (data, name, value, None, expired)
-    assert_equal (data['transferred'], transferred)
+    assert_equal (data['ismine'], mine)
 
 if __name__ == '__main__':
   NameListTest ().main ()

--- a/test/functional/name_rawtx.py
+++ b/test/functional/name_rawtx.py
@@ -86,11 +86,11 @@ class NameRawTxTest (NameTestFramework):
     data = self.nodes[0].name_list ("my-name")
     assert_equal (len (data), 1)
     assert_equal (data[0]['name'], "my-name")
-    assert_equal (data[0]['transferred'], True)
+    assert_equal (data[0]['ismine'], False)
     data = self.nodes[1].name_list ("my-name")
     assert_equal (len (data), 1)
     assert_equal (data[0]['name'], "my-name")
-    assert_equal (data[0]['transferred'], False)
+    assert_equal (data[0]['ismine'], True)
 
     assert_equal (balanceA + price, self.nodes[0].getbalance ())
     # Node 1 gets a block matured, take this into account.

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -6,6 +6,9 @@ echo "\nName expiration..."
 echo "\nName with immature inputs..."
 ./name_immature_inputs.py
 
+echo "\nName ismine field..."
+./name_ismine.py
+
 echo "\nName list..."
 ./name_list.py
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -160,6 +160,7 @@ BASE_SCRIPTS = [
     # name tests
     'name_expiration.py',
     'name_immature_inputs.py',
+    'name_ismine.py',
     'name_list.py',
     'name_listunspent.py',
     'name_multisig.py',


### PR DESCRIPTION
Based on the proposal in #219, this change removes the `transferred` field in the `name_list` output.  Instead, it adds the `ismine` field from `name_pending` consistenly to the output of all name RPCs (`name_show`, `name_history`, `name_scan`, `name_filter` and `name_list`, in addition to `name_pending` where it already is).

When the daemon is compiled with wallet support and the user has a wallet, then the `address` field that is already returned from all of them is checked against the wallet to populate `ismine`.  Everything should still work (same as `name_pending` now) even without a wallet, though, so this is strictly optional new functionality.

This change also adds a dedicated regtest for `ismine` in all RPCs.