### PR TITLE
Add "allowExisting" option for name_new

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -34,3 +34,10 @@
   name RPCs like `name_show` or `name_scan`.
   See the [proposal](https://github.com/namecoin/namecoin-core/issues/219) and
   the [implementation](https://github.com/namecoin/namecoin-core/pull/236).
+
+- `name_new` now checks whether a name exists already and by default rejects
+  to register an already existing name.  To override this check and get back
+  the old behaviour (where a `NAME_NEW` transaction can be sent for existing
+  names), set the new `allowExisting` option to true.
+  For more context, see the
+  [corresponding issue](https://github.com/namecoin/namecoin-core/issues/54).

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -193,10 +193,49 @@ getNameInfo (const valtype& name, const CNameData& data,
 
 } // anonymous namespace
 
-NameInfoHelp::NameInfoHelp (const std::string& ind)
-  : indent(ind)
+/* ************************************************************************** */
+
+HelpTextBuilder::HelpTextBuilder (const std::string& ind, const size_t col)
+  : indent(ind), docColumn(col)
 {
   result << indent << "{" << std::endl;
+}
+
+std::string
+HelpTextBuilder::finish (const std::string& trailing)
+{
+  result << indent << "}" << trailing << std::endl;
+  return result.str ();
+}
+
+HelpTextBuilder&
+HelpTextBuilder::withLine (const std::string& line)
+{
+  result << indent << "  " << line << std::endl;
+  return *this;
+}
+
+HelpTextBuilder&
+HelpTextBuilder::withField (const std::string& field, const std::string& doc)
+{
+  return withField (field, ",", doc);
+}
+
+HelpTextBuilder&
+HelpTextBuilder::withField (const std::string& field,
+                            const std::string& delim, const std::string& doc)
+{
+  assert (field.size () < docColumn);
+
+  result << indent << "  " << field << delim;
+  result << std::string (docColumn - field.size (), ' ') << doc << std::endl;
+
+  return *this;
+}
+
+NameInfoHelp::NameInfoHelp (const std::string& ind)
+  : HelpTextBuilder(ind, 25)
+{
   withField ("\"name\": xxxxx", "(string) the requested name");
   withField ("\"value\": xxxxx", "(string) the name's current value");
   withField ("\"txid\": xxxxx", "(string) the name's last update tx");
@@ -210,31 +249,12 @@ NameInfoHelp::NameInfoHelp (const std::string& ind)
 }
 
 NameInfoHelp&
-NameInfoHelp::withField (const std::string& field, const std::string& doc)
-{
-  constexpr size_t len = 25;
-  assert (field.size () < len);
-
-  result << indent << "  " << field << ",";
-  result << std::string (len - field.size (), ' ') << doc << std::endl;
-
-  return *this;
-}
-
-NameInfoHelp&
 NameInfoHelp::withExpiration ()
 {
   withField ("\"height\": xxxxx", "(numeric) the name's last update height");
   withField ("\"expires_in\": xxxxx", "(numeric) expire counter for the name");
   withField ("\"expired\": xxxxx", "(boolean) whether the name is expired");
   return *this;
-}
-
-std::string
-NameInfoHelp::finish (const std::string& trailing)
-{
-  result << indent << "}" << trailing << std::endl;
-  return result.str ();
 }
 
 /* ************************************************************************** */

--- a/src/rpc/names.h
+++ b/src/rpc/names.h
@@ -28,13 +28,14 @@ void addOwnershipInfo (const CScript& addr,
 #endif
 
 /**
- * Builder class for the help text of RPCs that return information about
- * names (like name_show, name_scan, name_pending or name_list).  Since the
- * exact fields contained and formatting to use depend on the case, this class
- * provides a simple and fluent interface to build the right help text for
- * each case.
+ * Builder class for help texts describing JSON objects that share a common
+ * part between multiple RPCs but also have specialised fields per RPC.
+ * This is the generic base class that provides the main implementation.
+ * Subclasses are used for the help text describing information about names
+ * returned by RPCs like name_show, and for the generic "options" argument
+ * that many name RPCs accept.
  */
-class NameInfoHelp
+class HelpTextBuilder
 {
 
 private:
@@ -42,14 +43,41 @@ private:
   std::ostringstream result;
   const std::string indent;
 
+  /** The column offset at which the "doc" strings are placed.  */
+  const size_t docColumn;
+
+public:
+
+  explicit HelpTextBuilder (const std::string& ind, size_t col);
+
+  HelpTextBuilder () = delete;
+  HelpTextBuilder (const HelpTextBuilder&) = delete;
+  void operator= (const HelpTextBuilder&) = delete;
+
+  HelpTextBuilder& withLine (const std::string& line);
+  HelpTextBuilder& withField (const std::string& field, const std::string& doc);
+  HelpTextBuilder& withField (const std::string& field,
+                              const std::string& delim, const std::string& doc);
+
+  std::string finish (const std::string& trailing);
+
+};
+
+/**
+ * Builder class for the help text of RPCs that return information about
+ * names (like name_show, name_scan, name_pending or name_list).  Since the
+ * exact fields contained and formatting to use depend on the case, this class
+ * provides a simple and fluent interface to build the right help text for
+ * each case.
+ */
+class NameInfoHelp : public HelpTextBuilder
+{
+
 public:
 
   explicit NameInfoHelp (const std::string& ind);
 
-  NameInfoHelp& withField (const std::string& field, const std::string& doc);
   NameInfoHelp& withExpiration ();
-
-  std::string finish (const std::string& trailing);
 
 };
 

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -115,20 +115,30 @@ void DestinationAddressHelper::finalise ()
 }
 
 /**
- * Returns the help text for the options argument for name operations.
+ * Builder for the help text of the "options" argument.
  */
-std::string getNameOpOptionsHelp ()
+class NameOpOptionsHelpBuilder : public HelpTextBuilder
 {
-  return "  {\n"
-         "    \"destAddress\"  (string, optional) The address to send the name output to\n"
-         "    \"sendCoins\"    (object, optional) Addresses to which coins should be sent additionally\n"
-         "      {\n"
-         "        \"addr1\": x,\n"
-         "        \"addr2\": y,\n"
-         "        ...\n"
-         "      }\n"
-         "  }\n";
-}
+
+public:
+
+  explicit NameOpOptionsHelpBuilder ()
+    : HelpTextBuilder("  ", 25)
+  {
+    withField ("\"destAddress\"",
+               "(string, optional) The address to send the name output to");
+
+    withField ("\"sendCoins\"", ":",
+               "(object, optional) Addresses to which coins should be"
+               " sent additionally");
+    withLine ("{");
+    withField ("  \"addr1\": x", "");
+    withField ("  \"addr2\": y", "");
+    withLine ("  ...");
+    withLine ("}");
+  }
+
+};
 
 /**
  * Sends a name output to the given name script.  This is the "final" step that
@@ -346,7 +356,8 @@ name_new (const JSONRPCRequest& request)
         "\nArguments:\n"
         "1. \"name\"          (string, required) the name to register\n"
         "2. \"options\"       (object, optional)\n"
-        + getNameOpOptionsHelp () +
+        + NameOpOptionsHelpBuilder ()
+            .finish ("") +
         "\nResult:\n"
         "[\n"
         "  xxxxx,   (string) the txid, required for name_firstupdate\n"
@@ -479,7 +490,8 @@ name_firstupdate (const JSONRPCRequest& request)
         "3. \"tx\"            (string, required) the name_new txid\n"
         "4. \"value\"         (string, required) value for the name\n"
         "5. \"options\"       (object, optional)\n"
-        + getNameOpOptionsHelp () +
+        + NameOpOptionsHelpBuilder ()
+            .finish ("") +
         "\nResult:\n"
         "\"txid\"             (string) the name_firstupdate's txid\n"
         "\nExamples:\n"
@@ -583,7 +595,8 @@ name_update (const JSONRPCRequest& request)
         "1. \"name\"          (string, required) the name to update\n"
         "2. \"value\"         (string, required) value for the name\n"
         "3. \"options\"       (object, optional)\n"
-        + getNameOpOptionsHelp () +
+        + NameOpOptionsHelpBuilder ()
+            .finish ("") +
         "\nResult:\n"
         "\"txid\"             (string) the name_update's txid\n"
         "\nExamples:\n"

--- a/test/functional/name_registration.py
+++ b/test/functional/name_registration.py
@@ -71,6 +71,17 @@ class NameRegistrationTest (NameTestFramework):
     self.checkNameHistory (1, "node-0", ["value-0"])
     self.checkNameHistory (1, "node-1", ["x" * 520])
 
+    # Verify the allowExisting option for name_new.
+    assert_raises_rpc_error (-25, 'exists already',
+                             self.nodes[0].name_new, "node-0")
+    assert_raises_rpc_error (-25, 'exists already',
+                             self.nodes[0].name_new, "node-0",
+                             {"allowExisting": False})
+    assert_raises_rpc_error (-3, 'Expected type bool for allowExisting',
+                             self.nodes[0].name_new, "other",
+                             {"allowExisting": 42.5})
+    self.nodes[0].name_new ("node-0", {"allowExisting": True})
+
     # Check for error with rand mismatch (wrong name)
     newA = self.nodes[0].name_new ("test-name")
     self.generate (0, 10)
@@ -86,8 +97,8 @@ class NameRegistrationTest (NameTestFramework):
     self.firstupdateName (0, "test-name", newA, "test-value")
 
     # Check for disallowed firstupdate when the name is active.
-    newSteal = self.nodes[1].name_new ("node-0")
-    newSteal2 = self.nodes[1].name_new ("node-0")
+    newSteal = self.nodes[1].name_new ("node-0", {"allowExisting": True})
+    newSteal2 = self.nodes[1].name_new ("node-0", {"allowExisting": True})
     self.generate (0, 19)
     self.checkName (1, "node-0", "value-0", 1, False)
     assert_raises_rpc_error (-25, 'this name is already active',


### PR DESCRIPTION
As proposed in #54, this leverages the new `options` argument to `name_new` to prevent accidental `name_new` transactions where the name exists already.  To do this, we add a new `allowExisting` field in the `options` and only allow sending a `name_new` for an existing name if that option is explicitly set by the user.

Relative to the current behaviour, this changes the "default" but still keeps the option for power users to override the check and get back the old behaviour.  Also, of course, there are no changes on the consensus level.