### PR TITLE
More explicit error code for missing tx input

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -209,7 +209,16 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
 bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, unsigned flags, CAmount& txfee)
 {
     if (!CheckNameTransaction (tx, nSpendHeight, inputs, state, flags))
-        return state.Invalid(false, 0, "", "Tx invalid for Namecoin");
+      {
+        /* Add a generic "invalid for name op" error to the state if none
+           was added by CheckNameTransaction already.  */
+        if (state.IsValid ()
+              || state.GetRejectCode () == 0
+              || state.GetRejectReason () == "")
+            state.Invalid (false, REJECT_INVALID, "tx-invalid-nameop",
+                           "Tx invalid for Namecoin");
+        return false;
+      }
 
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {

--- a/src/names/main.cpp
+++ b/src/names/main.cpp
@@ -407,7 +407,9 @@ CheckNameTransaction (const CTransaction& tx, unsigned nHeight,
       const COutPoint& prevout = tx.vin[i].prevout;
       Coin coin;
       if (!view.GetCoin (prevout, coin))
-        return error ("%s: failed to fetch input coin for %s", __func__, txid);
+        return state.Invalid (error ("%s: failed to fetch input coin for %s",
+                                     __func__, txid),
+                              REJECT_INVALID, "bad-txns-inputs-missingorspent");
 
       const CNameScript op(coin.out.scriptPubKey);
       if (op.isNameOp ())

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -93,9 +93,7 @@ class MiningTest(BitcoinTestFramework):
         bad_tx.vin[0].prevout.hash = 255
         bad_tx.rehash()
         bad_block.vtx.append(bad_tx)
-        # In Namecoin, we fail not with bad-txns-inputs-missingorspent, but
-        # in CheckNameTransaction due to the missing input.
-        assert_template(node, bad_block, 'rejected')
+        assert_template(node, bad_block, 'bad-txns-inputs-missingorspent')
 
         self.log.info("getblocktemplate: Test nonfinal transaction")
         bad_block = copy.deepcopy(block)


### PR DESCRIPTION
When `CheckNameTransaction` fails because the prev tx input is not found, return the same `bad-txns-inputs-missingorspent` error code that upstream Bitcoin returns, rather than a general "name tx verification failed" one.  This allows us to stick closer to upstream code in the test also.

For all other cases, if no specific error code is returned from `CheckNameTransaction`, return at least a new `tx-invalid-nameop` code and `REJECT_INVALID`.