### PR TITLE
Update the signmessage "magic string"

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -46,3 +46,9 @@
   on the new commands `namenew`, ` namefirstupdate` and `nameupdate`.  For the
   exact usage, see the
   [proposal](https://github.com/namecoin/namecoin-core/issues/147#issuecomment-402429258).
+
+- The "magic string" used for `signmessage` and `verifymessage` has been updated
+  to be specific to Namecoin (previously, the one from Bitcoin was used).  This
+  means that messages signed previously won't validate anymore.  It is, however,
+  still possible to verify them customly; so old signatures can still be used
+  as proofs in the future if necessary.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -243,7 +243,7 @@ std::atomic_bool g_is_mempool_loaded{false};
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const std::string strMessageMagic = "Bitcoin Signed Message:\n";
+const std::string strMessageMagic = "Namecoin Signed Message:\n";
 
 // Internal stuff
 namespace {

--- a/test/functional/rpc_signmessage.py
+++ b/test/functional/rpc_signmessage.py
@@ -19,7 +19,7 @@ class SignMessagesTest(BitcoinTestFramework):
         self.log.info('test signing with priv_key')
         priv_key = 'cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N'
         address = 'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB'
-        expected_signature = 'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0='
+        expected_signature = 'Hx6I/QmVmh4EePAdNrPm1ud7M/w6r9Oz2FNMUz4jxTPnW3FiYTTjNWzV1ESB2NeeoAIG7hEsNVRaVFLyE3dG2VE='
         signature = self.nodes[0].signmessagewithprivkey(priv_key, message)
         assert_equal(expected_signature, signature)
         assert(self.nodes[0].verifymessage(address, signature, message))


### PR DESCRIPTION
`signmessage` and `verifymessage` use a "magic string" prefix.  Previously, Namecoin was using the same as upstream Bitcoin.  This has the confusing effect that signatures can be interchanged between Bitcoin and Namecoin.  (But of course, someone still has to own the private key to create a valid signature for any of them in the first place.)

This commit changes the magic string to be specific to Namecoin, which makes sure that messages signed in Namecoin can only be validated in Namecoin, and messages signed in Bitcoin only with Bitcoin (as most people likely expect).

Note that this means that old signatures won't validate anymore with `verifymessage`.  But it is probably unlikely that this was used a lot at all.  Furthermore, the signature can of course still be verified in a custom way (e.g. using Bitcoin Core), so old signatures can still be used as a proof if that is necessary.