### PR TITLE
Main support for name/value encodings

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -42,6 +42,17 @@
   For more context, see the
   [corresponding issue](https://github.com/namecoin/namecoin-core/issues/54).
 
+- Names and values in the RPC interface (and to a limited degree also the REST
+  interface and `namecoin-tx`) can now be specified and requested in one of
+  three encodings (`ascii`, `utf8` and `hex`).  This fixes a long-standing issue
+  with names or values that were invalid UTF-8, by adding proper support for
+  pure binary data as well as validation of the data before returning it as
+  ASCII or UTF-8.  The encodings default to `ascii` now.  To get back behaviour
+  close to the previous one, specify `-nameencoding=utf8` and
+  `-valueencoding=utf8`.  The detailed specification of the new encoding options
+  can be found in the
+  [Github issue](https://github.com/namecoin/namecoin-core/issues/246).
+
 - The `namecoin-tx` utility has now support for creating name operations based
   on the new commands `namenew`, ` namefirstupdate` and `nameupdate`.  For the
   exact usage, see the

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   names/common.h \
+  names/encoding.h \
   names/main.h \
   net.h \
   net_processing.h \
@@ -235,6 +236,7 @@ libbitcoin_server_a_SOURCES = \
   dbwrapper.cpp \
   merkleblock.cpp \
   miner.cpp \
+  names/encoding.cpp \
   names/main.cpp \
   net.cpp \
   net_processing.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -236,7 +236,6 @@ libbitcoin_server_a_SOURCES = \
   dbwrapper.cpp \
   merkleblock.cpp \
   miner.cpp \
-  names/encoding.cpp \
   names/main.cpp \
   net.cpp \
   net_processing.cpp \
@@ -400,6 +399,7 @@ libbitcoin_common_a_SOURCES = \
   key_io.cpp \
   keystore.cpp \
   names/common.cpp \
+  names/encoding.cpp \
   netaddress.cpp \
   netbase.cpp \
   policy/feerate.cpp \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -12,6 +12,7 @@
 #include <core_io.h>
 #include <key_io.h>
 #include <keystore.h>
+#include <names/encoding.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
@@ -38,6 +39,8 @@ static void SetupBitcoinTxArgs()
     gArgs.AddArg("-create", "Create new, empty TX.", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-json", "Select JSON output", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-txid", "Output only the hex-encoded transaction id of the resultant transaction.", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-nameencoding", strprintf("The encoding to use for names in the JSON output (default: %s)", EncodingToString(DEFAULT_NAME_ENCODING)), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-valueencoding", strprintf("The encoding to use for values in the JSON output (default: %s)", EncodingToString(DEFAULT_VALUE_ENCODING)), false, OptionsCategory::OPTIONS);
     SetupChainParamsBaseOptions();
 
     gArgs.AddArg("delin=N", "Delete input N from TX", false, OptionsCategory::COMMANDS);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -7,7 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <key_io.h>
-#include <names/common.h>
+#include <names/encoding.h>
 #include <script/names.h>
 #include <script/script.h>
 #include <script/standard.h>
@@ -265,27 +265,21 @@ UniValue NameOpToUniv (const CNameScript& nameOp)
         break;
 
       case OP_NAME_FIRSTUPDATE:
-        {
-          const std::string name = ValtypeToString (nameOp.getOpName ());
-          const std::string value = ValtypeToString (nameOp.getOpValue ());
-
-          result.pushKV ("op", "name_firstupdate");
-          result.pushKV ("name", name);
-          result.pushKV ("value", value);
-          result.pushKV ("rand", HexStr (nameOp.getOpRand ()));
-          break;
-        }
+        result.pushKV ("op", "name_firstupdate");
+        AddEncodedNameToUniv (result, "name", nameOp.getOpName (),
+                              ConfiguredNameEncoding ());
+        AddEncodedNameToUniv (result, "value", nameOp.getOpValue (),
+                              ConfiguredValueEncoding ());
+        result.pushKV ("rand", HexStr (nameOp.getOpRand ()));
+        break;
 
       case OP_NAME_UPDATE:
-        {
-          const std::string name = ValtypeToString (nameOp.getOpName ());
-          const std::string value = ValtypeToString (nameOp.getOpValue ());
-
-          result.pushKV ("op", "name_update");
-          result.pushKV ("name", name);
-          result.pushKV ("value", value);
-          break;
-        }
+        result.pushKV ("op", "name_update");
+        AddEncodedNameToUniv (result, "name", nameOp.getOpName (),
+                              ConfiguredNameEncoding ());
+        AddEncodedNameToUniv (result, "value", nameOp.getOpValue (),
+                              ConfiguredValueEncoding ());
+        break;
 
       default:
         assert (false);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -23,6 +23,7 @@
 #include <key.h>
 #include <validation.h>
 #include <miner.h>
+#include <names/encoding.h>
 #include <netbase.h>
 #include <net.h>
 #include <net_processing.h>
@@ -519,6 +520,9 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), true, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", false, OptionsCategory::RPC);
+
+    gArgs.AddArg("-nameencoding=<enc>", strprintf("Sets the default encoding used for names in the RPC interface (default: %s)", EncodingToString(DEFAULT_NAME_ENCODING)), false, OptionsCategory::RPC);
+    gArgs.AddArg("-valueencoding=<enc>", strprintf("Sets the default encoding used for values in the RPC interface (default: %s)", EncodingToString(DEFAULT_VALUE_ENCODING)), false, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", false, OptionsCategory::OPTIONS);

--- a/src/names/common.h
+++ b/src/names/common.h
@@ -20,17 +20,6 @@ class CDBBatch;
 extern bool fNameHistory;
 
 /**
- * Construct a valtype (e. g., name) from a string.
- * @param str The string input.
- * @return The corresponding valtype.
- */
-inline valtype
-ValtypeFromString (const std::string& str)
-{
-  return valtype (str.begin (), str.end ());
-}
-
-/**
  * Convert a valtype to a string.
  * @param val The valtype value.
  * @return Corresponding string.

--- a/src/names/common.h
+++ b/src/names/common.h
@@ -19,17 +19,6 @@ class CDBBatch;
 /** Whether or not name history is enabled.  */
 extern bool fNameHistory;
 
-/**
- * Convert a valtype to a string.
- * @param val The valtype value.
- * @return Corresponding string.
- */
-inline std::string
-ValtypeToString (const valtype& val)
-{
-  return std::string (val.begin (), val.end ());
-}
-
 /* ************************************************************************** */
 /* CNameData.  */
 

--- a/src/names/encoding.cpp
+++ b/src/names/encoding.cpp
@@ -161,7 +161,7 @@ DecodeName (const std::string& str, const NameEncoding enc)
     {
     case NameEncoding::ASCII:
     case NameEncoding::UTF8:
-      return ValtypeFromString (str);
+      return valtype (str.begin (), str.end ());
 
     case NameEncoding::HEX:
       return ParseHex (str);

--- a/src/names/encoding.cpp
+++ b/src/names/encoding.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2018 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <names/encoding.h>
+
+#include <names/common.h>
+#include <utilstrencodings.h>
+
+#include <univalue.h>
+
+#include <cassert>
+#include <sstream>
+
+NameEncoding
+EncodingFromString (const std::string& str)
+{
+  if (str == "ascii")
+    return NameEncoding::ASCII;
+  if (str == "utf8")
+    return NameEncoding::UTF8;
+  if (str == "hex")
+    return NameEncoding::HEX;
+
+  throw std::invalid_argument ("invalid name/value encoding: " + str);
+}
+
+std::string
+EncodingToString (NameEncoding enc)
+{
+  switch (enc)
+    {
+    case NameEncoding::ASCII:
+      return "ascii";
+    case NameEncoding::UTF8:
+      return "utf8";
+    case NameEncoding::HEX:
+      return "hex";
+    }
+
+  /* NameEncoding values are only ever created internally in the binary
+     and not received externally (except as string).  Thus it should never
+     happen (and if it does, is a severe bug) that we see an unexpected
+     value.  */
+  assert (false);
+}
+
+namespace
+{
+
+bool
+IsStringValid (const std::string& str, const NameEncoding enc)
+{
+  switch (enc)
+    {
+    case NameEncoding::ASCII:
+      for (const unsigned char c : str)
+        if (c < 0x20 || c >= 0x80)
+          return false;
+      return true;
+
+    case NameEncoding::UTF8:
+      if (!IsValidUtf8String (str))
+        return false;
+      return true;
+
+    case NameEncoding::HEX:
+      return IsHex (str);
+    }
+
+  assert (false);
+}
+
+void
+VerifyStringValid (const std::string& str, const NameEncoding enc)
+{
+  if (IsStringValid (str, enc))
+    return;
+
+  throw InvalidNameString (enc, str);
+}
+
+std::string
+InvalidNameStringMessage (const NameEncoding enc, const std::string& invalidStr)
+{
+  std::ostringstream msg;
+  msg << "invalid string for encoding " << EncodingToString (enc) << ":"
+      << " " << invalidStr;
+  return msg.str ();
+}
+
+} // anonymous namespace
+
+InvalidNameString::InvalidNameString (const NameEncoding enc,
+                                      const std::string& invalidStr)
+  : std::invalid_argument (InvalidNameStringMessage (enc, invalidStr))
+{}
+
+std::string
+EncodeName (const valtype& data, const NameEncoding enc)
+{
+  std::string res;
+  switch (enc)
+    {
+    case NameEncoding::ASCII:
+    case NameEncoding::UTF8:
+      res = ValtypeToString (data);
+      break;
+
+    case NameEncoding::HEX:
+      res = HexStr (data.begin (), data.end ());
+      break;
+    }
+
+  VerifyStringValid (res, enc);
+  return res;
+}
+
+valtype
+DecodeName (const std::string& str, const NameEncoding enc)
+{
+  VerifyStringValid (str, enc);
+
+  switch (enc)
+    {
+    case NameEncoding::ASCII:
+    case NameEncoding::UTF8:
+      return ValtypeFromString (str);
+
+    case NameEncoding::HEX:
+      return ParseHex (str);
+    }
+
+  assert (false);
+}

--- a/src/names/encoding.cpp
+++ b/src/names/encoding.cpp
@@ -169,3 +169,16 @@ DecodeName (const std::string& str, const NameEncoding enc)
 
   assert (false);
 }
+
+std::string
+EncodeNameForMessage (const valtype& data)
+{
+  try
+    {
+      return "'" + EncodeName (data, NameEncoding::ASCII) + "'";
+    }
+  catch (const InvalidNameString& exc)
+    {
+      return "0x" + EncodeName (data, NameEncoding::HEX);
+    }
+}

--- a/src/names/encoding.cpp
+++ b/src/names/encoding.cpp
@@ -4,13 +4,49 @@
 
 #include <names/encoding.h>
 
+#include <logging.h>
 #include <names/common.h>
+#include <util.h>
 #include <utilstrencodings.h>
 
 #include <univalue.h>
 
 #include <cassert>
 #include <sstream>
+
+namespace
+{
+
+NameEncoding
+EncodingFromOptions (const std::string& option, const NameEncoding defaultVal)
+{
+  const std::string value
+      = gArgs.GetArg (option, EncodingToString (defaultVal));
+  try
+    {
+      return EncodingFromString (value);
+    }
+  catch (const std::invalid_argument& exc)
+    {
+      LogPrintf ("Invalid value for %s:\n  %s\n  falling back to default %s\n",
+                 option, exc.what (), EncodingToString (defaultVal));
+      return defaultVal;
+    }
+}
+
+} // anonymous namespace
+
+NameEncoding
+ConfiguredNameEncoding ()
+{
+  return EncodingFromOptions ("-nameencoding", DEFAULT_NAME_ENCODING);
+}
+
+NameEncoding
+ConfiguredValueEncoding ()
+{
+  return EncodingFromOptions ("-valueencoding", DEFAULT_VALUE_ENCODING);
+}
 
 NameEncoding
 EncodingFromString (const std::string& str)

--- a/src/names/encoding.cpp
+++ b/src/names/encoding.cpp
@@ -5,7 +5,6 @@
 #include <names/encoding.h>
 
 #include <logging.h>
-#include <names/common.h>
 #include <util.h>
 #include <utilstrencodings.h>
 
@@ -140,7 +139,7 @@ EncodeName (const valtype& data, const NameEncoding enc)
     {
     case NameEncoding::ASCII:
     case NameEncoding::UTF8:
-      res = ValtypeToString (data);
+      res = std::string (data.begin (), data.end ());
       break;
 
     case NameEncoding::HEX:
@@ -181,4 +180,19 @@ EncodeNameForMessage (const valtype& data)
     {
       return "0x" + EncodeName (data, NameEncoding::HEX);
     }
+}
+
+void
+AddEncodedNameToUniv (UniValue& obj, const std::string& key,
+                      const valtype& data, const NameEncoding enc)
+{
+  try
+    {
+      obj.pushKV (key, EncodeName (data, enc));
+    }
+  catch (const InvalidNameString& exc)
+    {
+      obj.pushKV (key + "_error", "invalid data for " + EncodingToString (enc));
+    }
+  obj.pushKV (key + "_encoding", EncodingToString (enc));
 }

--- a/src/names/encoding.h
+++ b/src/names/encoding.h
@@ -31,6 +31,14 @@ enum class NameEncoding
   HEX,
 };
 
+/* Accessors to the "default" encodings as configured by startup options.  */
+NameEncoding ConfiguredNameEncoding ();
+NameEncoding ConfiguredValueEncoding ();
+
+/* The options defaults for the encodings.  */
+static constexpr NameEncoding DEFAULT_NAME_ENCODING = NameEncoding::ASCII;
+static constexpr NameEncoding DEFAULT_VALUE_ENCODING = NameEncoding::ASCII;
+
 /* Utility functions to convert encodings to/from the enum.  They throw
    std::invalid_argument if the conversion fails.  */
 NameEncoding EncodingFromString (const std::string& str);

--- a/src/names/encoding.h
+++ b/src/names/encoding.h
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <string>
 
+class UniValue;
+
 /**
  * Enum for the possible encodings of names/values in the RPC interface.
  */
@@ -78,5 +80,14 @@ valtype DecodeName (const std::string& str, NameEncoding enc);
  * the string in hex.
  */
 std::string EncodeNameForMessage (const valtype& data);
+
+/**
+ * Adds an encoded name or value to the UniValue object with the given key.
+ * Also adds "key_encoding" with the chosen encoding's name.  If the data
+ * cannot be represented with the encoding, a "key_error" field is added
+ * instead of "key" itself.
+ */
+void AddEncodedNameToUniv (UniValue& obj, const std::string& key,
+                           const valtype& data, NameEncoding enc);
 
 #endif // H_BITCOIN_NAMES_ENCODING

--- a/src/names/encoding.h
+++ b/src/names/encoding.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_BITCOIN_NAMES_ENCODING
+#define H_BITCOIN_NAMES_ENCODING
+
+#include <script/script.h>
+
+#include <stdexcept>
+#include <string>
+
+/**
+ * Enum for the possible encodings of names/values in the RPC interface.
+ */
+enum class NameEncoding
+{
+  /**
+   * Only printable ASCII characters (code in [0x20, 0x80)) are allowed.
+   */
+  ASCII,
+
+  /**
+   * Valid UTF-8 with printable characters (code >=0x20).
+   */
+  UTF8,
+
+  /**
+   * Hex-encoded arbitrary binary data.
+   */
+  HEX,
+};
+
+/* Utility functions to convert encodings to/from the enum.  They throw
+   std::invalid_argument if the conversion fails.  */
+NameEncoding EncodingFromString (const std::string& str);
+std::string EncodingToString (NameEncoding enc);
+
+/**
+ * Exception that is thrown if a name/value string is invalid according
+ * to the chosen encoding.
+ */
+class InvalidNameString : public std::invalid_argument
+{
+
+public:
+
+  InvalidNameString () = delete;
+
+  InvalidNameString (NameEncoding enc, const std::string& invalidStr);
+
+};
+
+/**
+ * Encodes a name or value to a string with the given encoding.  Throws
+ * InvalidNameString if the data is not valid for the encoding.
+ */
+std::string EncodeName (const valtype& data, NameEncoding enc);
+
+/**
+ * Decodes a string to a raw name/value.  Throws InvalidNameString
+ * if the string is invalid for the requested encoding.
+ */
+valtype DecodeName (const std::string& str, NameEncoding enc);
+
+#endif // H_BITCOIN_NAMES_ENCODING

--- a/src/names/encoding.h
+++ b/src/names/encoding.h
@@ -71,4 +71,12 @@ std::string EncodeName (const valtype& data, NameEncoding enc);
  */
 valtype DecodeName (const std::string& str, NameEncoding enc);
 
+/**
+ * Encodes a name or value to a string that is meant to be printed to logs
+ * or returned as part of a larger message (e.g. in the "listtransactions"
+ * description).  This converts to ASCII if possible and otherwise returns
+ * the string in hex.
+ */
+std::string EncodeNameForMessage (const valtype& data);
+
 #endif // H_BITCOIN_NAMES_ENCODING

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -8,6 +8,7 @@
 #include <core_io.h>
 #include <index/txindex.h>
 #include <names/common.h>
+#include <names/encoding.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <validation.h>
@@ -643,15 +644,15 @@ static bool rest_name(HTTPRequest* req, const std::string& strURIPart)
     CNameData data;
     if (!pcoinsTip->GetName(plainName, data))
         return RESTERR(req, HTTP_NOT_FOUND,
-                       "'" + ValtypeToString(plainName) + "' not found");
+                       EncodeNameForMessage (plainName) + " not found");
 
     switch (rf)
     {
     case RetFormat::BINARY:
     {
-        const std::string binVal = ValtypeToString(data.getValue());
+        const std::string val(data.getValue().begin(), data.getValue().end());
         req->WriteHeader("Content-Type", "application/octet-stream");
-        req->WriteReply(HTTP_OK, binVal);
+        req->WriteReply(HTTP_OK, val);
         return true;
     }
 

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -39,8 +39,8 @@ getNameInfo (const valtype& name, const valtype& value,
              const COutPoint& outp, const CScript& addr)
 {
   UniValue obj(UniValue::VOBJ);
-  obj.pushKV ("name", ValtypeToString (name));
-  obj.pushKV ("value", ValtypeToString (value));
+  AddEncodedNameToUniv (obj, "name", name, ConfiguredNameEncoding ());
+  AddEncodedNameToUniv (obj, "value", value, ConfiguredValueEncoding ());
   obj.pushKV ("txid", outp.hash.GetHex ());
   obj.pushKV ("vout", static_cast<int> (outp.n));
 

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -538,10 +538,17 @@ name_filter (const JSONRPCRequest& request)
 
       if (haveRegexp)
         {
-          const std::string nameStr = ValtypeToString (name);
-          boost::xpressive::smatch matches;
-          if (!boost::xpressive::regex_search (nameStr, matches, regexp))
-            continue;
+          try
+            {
+              const std::string nameStr = EncodeName (name, NameEncoding::UTF8);
+              boost::xpressive::smatch matches;
+              if (!boost::xpressive::regex_search (nameStr, matches, regexp))
+                continue;
+            }
+          catch (const InvalidNameString& exc)
+            {
+              continue;
+            }
         }
 
       if (from > 0)

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -311,7 +311,7 @@ name_show (const JSONRPCRequest& request)
     if (!pcoinsTip->GetName (name, data))
       {
         std::ostringstream msg;
-        msg << "name not found: '" << ValtypeToString (name) << "'";
+        msg << "name not found: " << EncodeNameForMessage (name);
         throw JSONRPCError (RPC_WALLET_ERROR, msg.str ());
       }
   }
@@ -366,7 +366,7 @@ name_history (const JSONRPCRequest& request)
     if (!pcoinsTip->GetName (name, data))
       {
         std::ostringstream msg;
-        msg << "name not found: '" << ValtypeToString (name) << "'";
+        msg << "name not found: " << EncodeNameForMessage (name);
         throw JSONRPCError (RPC_WALLET_ERROR, msg.str ());
       }
 

--- a/src/rpc/names.h
+++ b/src/rpc/names.h
@@ -7,6 +7,8 @@
 
 #include <script/script.h>
 
+#include <names/encoding.h>
+
 #include <sstream>
 #include <string>
 
@@ -26,6 +28,12 @@ void addOwnershipInfo (const CScript& addr,
                        const CWallet* pwallet,
                        UniValue& data);
 #endif
+
+/**
+ * Decodes a name/value given through the RPC interface and throws a
+ * JSONRPCError if it is invalid for the requested encoding.
+ */
+valtype DecodeNameFromRPCOrThrow (const UniValue& val, NameEncoding enc);
 
 /**
  * Builder class for help texts describing JSON objects that share a common

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -90,6 +90,9 @@ enum RPCErrorCode
 
     //! Unused reserved codes, kept around for backwards compatibility. Do not reuse.
     RPC_FORBIDDEN_BY_SAFE_MODE      = -2,  //!< Server is in safe mode, and command is not allowed in safe mode
+
+    //! Namecoin-specific error codes
+    RPC_NAME_INVALID_ENCODING       = -1000, //!< A name or value is invalid for the specified encoding
 };
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);

--- a/src/test/name_tests.cpp
+++ b/src/test/name_tests.cpp
@@ -1180,6 +1180,16 @@ BOOST_FIXTURE_TEST_CASE (encoding_hex, EncodingTestSetup)
   InvalidString ("zz");
 }
 
+BOOST_AUTO_TEST_CASE (encode_name_for_message)
+{
+  BOOST_CHECK_EQUAL (
+      EncodeNameForMessage (DecodeName ("d/abc", NameEncoding::ASCII)),
+      "'d/abc'");
+  BOOST_CHECK_EQUAL (
+      EncodeNameForMessage (DecodeName ("00ff", NameEncoding::HEX)),
+      "0x00ff");
+}
+
 /* ************************************************************************** */
 
 BOOST_AUTO_TEST_SUITE_END ()

--- a/src/test/name_tests.cpp
+++ b/src/test/name_tests.cpp
@@ -14,6 +14,7 @@
 #include <txdb.h>
 #include <txmempool.h>
 #include <undo.h>
+#include <util.h>
 #include <validation.h>
 
 #include <test/test_bitcoin.h>
@@ -1077,6 +1078,24 @@ BOOST_AUTO_TEST_CASE (encoding_to_from_string)
   BOOST_CHECK_EQUAL (EncodingToString (NameEncoding::HEX), "hex");
 
   BOOST_CHECK_THROW (EncodingFromString ("invalid"), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE (encoding_args)
+{
+  BOOST_CHECK (ConfiguredNameEncoding () == DEFAULT_NAME_ENCODING);
+  BOOST_CHECK (ConfiguredValueEncoding () == DEFAULT_VALUE_ENCODING);
+
+  gArgs.ForceSetArg ("-nameencoding", "utf8");
+  BOOST_CHECK (ConfiguredNameEncoding () == NameEncoding::UTF8);
+  BOOST_CHECK (ConfiguredValueEncoding () == DEFAULT_VALUE_ENCODING);
+
+  gArgs.ForceSetArg ("-valueencoding", "hex");
+  BOOST_CHECK (ConfiguredNameEncoding () == NameEncoding::UTF8);
+  BOOST_CHECK (ConfiguredValueEncoding () == NameEncoding::HEX);
+
+  gArgs.ForceSetArg ("-nameencoding", "invalid");
+  BOOST_CHECK (ConfiguredNameEncoding () == DEFAULT_NAME_ENCODING);
+  BOOST_CHECK (ConfiguredValueEncoding () == NameEncoding::HEX);
 }
 
 namespace

--- a/src/test/name_tests.cpp
+++ b/src/test/name_tests.cpp
@@ -31,11 +31,14 @@
    the test-suite name works with grep as done in the Makefile.  */
 BOOST_FIXTURE_TEST_SUITE(name_tests, TestingSetup)
 
+namespace
+{
+
 /**
  * Utility function that returns a sample address script to use in the tests.
  * @return A script that represents a simple address.
  */
-static CScript
+CScript
 getTestAddress ()
 {
   const CTxDestination dest
@@ -44,6 +47,8 @@ getTestAddress ()
 
   return GetScriptForDestination (dest);
 }
+
+} // anonymous namespace
 
 /* ************************************************************************** */
 
@@ -54,8 +59,8 @@ BOOST_AUTO_TEST_CASE (name_scripts)
   BOOST_CHECK (!opNone.isNameOp ());
   BOOST_CHECK (opNone.getAddress () == addr);
 
-  const valtype name = ValtypeFromString ("my-cool-name");
-  const valtype value = ValtypeFromString ("42!");
+  const valtype name = DecodeName ("my-cool-name", NameEncoding::ASCII);
+  const valtype value = DecodeName ("42!", NameEncoding::ASCII);
 
   const valtype rand(20, 'x');
   valtype toHash(rand);
@@ -95,9 +100,9 @@ BOOST_AUTO_TEST_CASE (name_scripts)
 
 BOOST_AUTO_TEST_CASE (name_database)
 {
-  const valtype name1 = ValtypeFromString ("database-test-name-1");
-  const valtype name2 = ValtypeFromString ("database-test-name-2");
-  const valtype value = ValtypeFromString ("my-value");
+  const valtype name1 = DecodeName ("db-test-name-1", NameEncoding::ASCII);
+  const valtype name2 = DecodeName ("db-test-name-2", NameEncoding::ASCII);
+  const valtype value = DecodeName ("my-value", NameEncoding::ASCII);
   const CScript addr = getTestAddress ();
 
   /* Choose two height values.  To verify that serialisation of the
@@ -317,8 +322,8 @@ CNameData
 NameIterationTester::getNextData ()
 {
   const CScript addr = getTestAddress ();
-  const valtype name = ValtypeFromString ("dummy");
-  const valtype value = ValtypeFromString ("abc");
+  const valtype name = DecodeName ("dummy", NameEncoding::ASCII);
+  const valtype value = DecodeName ("abc", NameEncoding::ASCII);
   const CScript updateScript = CNameScript::buildNameUpdate (addr, name, value);
   const CNameScript nameOp(updateScript);
 
@@ -341,7 +346,7 @@ NameIterationTester::verify (const CCoinsView& view) const
   /* Seek the iterator to the end first for "maximum confusion".  This ensures
      that seeking to valtype() works.  */
   std::unique_ptr<CNameIterator> iter(view.IterateNames ());
-  const valtype end = ValtypeFromString ("zzzzzzzzzzzzzzzz");
+  const valtype end = DecodeName ("zzzzzzzzzzzzzzzz", NameEncoding::ASCII);
   {
     valtype name;
     CNameData nameData;
@@ -414,7 +419,7 @@ NameIterationTester::getNamesFromIterator (CNameIterator& iter)
 void
 NameIterationTester::add (const std::string& n)
 {
-  const valtype& name = ValtypeFromString (n);
+  const valtype& name = DecodeName (n, NameEncoding::ASCII);
   const CNameData testData = getNextData ();
 
   assert (data.count (name) == 0);
@@ -427,7 +432,7 @@ NameIterationTester::add (const std::string& n)
 void
 NameIterationTester::update (const std::string& n)
 {
-  const valtype& name = ValtypeFromString (n);
+  const valtype& name = DecodeName (n, NameEncoding::ASCII);
   const CNameData testData = getNextData ();
 
   assert (data.count (name) == 1);
@@ -440,7 +445,7 @@ NameIterationTester::update (const std::string& n)
 void
 NameIterationTester::remove (const std::string& n)
 {
-  const valtype& name = ValtypeFromString (n);
+  const valtype& name = DecodeName (n, NameEncoding::ASCII);
 
   assert (data.count (name) == 1);
   data.erase (name);
@@ -505,9 +510,9 @@ addTestCoin (const CScript& scr, unsigned nHeight, CCoinsViewCache& view)
 
 BOOST_AUTO_TEST_CASE (name_tx_verification)
 {
-  const valtype name1 = ValtypeFromString ("test-name-1");
-  const valtype name2 = ValtypeFromString ("test-name-2");
-  const valtype value = ValtypeFromString ("my-value");
+  const valtype name1 = DecodeName ("test-name-1", NameEncoding::ASCII);
+  const valtype name2 = DecodeName ("test-name-2", NameEncoding::ASCII);
+  const valtype value = DecodeName ("my-value", NameEncoding::ASCII);
 
   const valtype tooLongName(256, 'x');
   const valtype tooLongValue(1024, 'x');
@@ -700,9 +705,9 @@ BOOST_AUTO_TEST_CASE (name_updates_undo)
   /* Enable name history to test this on the go.  */
   fNameHistory = true;
 
-  const valtype name = ValtypeFromString ("database-test-name");
-  const valtype value1 = ValtypeFromString ("old-value");
-  const valtype value2 = ValtypeFromString ("new-value");
+  const valtype name = DecodeName ("db-test-name", NameEncoding::ASCII);
+  const valtype value1 = DecodeName ("old-value", NameEncoding::ASCII);
+  const valtype value2 = DecodeName ("new-value", NameEncoding::ASCII);
   const CScript addr = getTestAddress ();
 
   CCoinsView dummyView;
@@ -771,9 +776,9 @@ BOOST_AUTO_TEST_CASE (name_updates_undo)
 
 BOOST_AUTO_TEST_CASE (name_expire_utxo)
 {
-  const valtype name1 = ValtypeFromString ("test-name-1");
-  const valtype name2 = ValtypeFromString ("test-name-2");
-  const valtype value = ValtypeFromString ("value");
+  const valtype name1 = DecodeName ("test-name-1", NameEncoding::ASCII);
+  const valtype name2 = DecodeName ("test-name-2", NameEncoding::ASCII);
+  const valtype value = DecodeName ("value", NameEncoding::ASCII);
   const CScript addr = getTestAddress ();
   
   const CScript upd1 = CNameScript::buildNameUpdate (addr, name1, value);
@@ -863,11 +868,11 @@ BOOST_AUTO_TEST_CASE (name_mempool)
   LOCK(mempool.cs);
   mempool.clear ();
 
-  const valtype nameReg = ValtypeFromString ("name-reg");
-  const valtype nameUpd = ValtypeFromString ("name-upd");
-  const valtype value = ValtypeFromString ("value");
-  const valtype valueA = ValtypeFromString ("value-a");
-  const valtype valueB = ValtypeFromString ("value-b");
+  const valtype nameReg = DecodeName ("name-reg", NameEncoding::ASCII);
+  const valtype nameUpd = DecodeName ("name-upd", NameEncoding::ASCII);
+  const valtype value = DecodeName ("value", NameEncoding::ASCII);
+  const valtype valueA = DecodeName ("value-a", NameEncoding::ASCII);
+  const valtype valueB = DecodeName ("value-b", NameEncoding::ASCII);
   const CScript addr = getTestAddress ();
   const CScript addr2 = (CScript (addr) << OP_RETURN);
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -7,6 +7,7 @@
 
 #include <chainparams.h>
 #include <hash.h>
+#include <names/encoding.h>
 #include <random.h>
 #include <pow.h>
 #include <script/names.h>
@@ -119,8 +120,8 @@ bool CCoinsViewDB::GetNamesForHeight(unsigned nHeight, std::set<valtype>& names)
 
         const valtype& name = entry.name;
         if (names.count(name) > 0)
-            return error("%s : duplicate name '%s' in expire index",
-                         __func__, ValtypeToString(name).c_str());
+            return error("%s : duplicate name %s in expire index",
+                         __func__, EncodeNameForMessage(name));
         names.insert(name);
     }
 
@@ -389,7 +390,7 @@ bool CCoinsViewDB::ValidateNameDB() const
                     const valtype& name = nameOp.getOpName();
                     if (namesInUTXO.count(name) > 0)
                         return error("%s : name %s duplicated in UTXO set",
-                                     __func__, ValtypeToString(name).c_str());
+                                     __func__, EncodeNameForMessage(name));
                     namesInUTXO.insert(nameOp.getOpName());
                 }
             }
@@ -409,7 +410,7 @@ bool CCoinsViewDB::ValidateNameDB() const
 
             if (nameHeightsData.count(name) > 0)
                 return error("%s : name %s duplicated in name index",
-                             __func__, ValtypeToString(name).c_str());
+                             __func__, EncodeNameForMessage(name));
             nameHeightsData.insert(std::make_pair(name, data.getHeight()));
             
             /* Expiration is checked at height+1, because that matches
@@ -430,7 +431,7 @@ bool CCoinsViewDB::ValidateNameDB() const
 
             if (namesWithHistory.count(name) > 0)
                 return error("%s : name %s has duplicate history",
-                             __func__, ValtypeToString(name).c_str());
+                             __func__, EncodeNameForMessage(name));
             namesWithHistory.insert(name);
             break;
         }
@@ -446,7 +447,7 @@ bool CCoinsViewDB::ValidateNameDB() const
 
             if (nameHeightsIndex.count(name) > 0)
                 return error("%s : name %s duplicated in expire idnex",
-                             __func__, ValtypeToString(name).c_str());
+                             __func__, EncodeNameForMessage(name));
 
             nameHeightsIndex.insert(std::make_pair(name, entry.nHeight));
             break;
@@ -467,18 +468,18 @@ bool CCoinsViewDB::ValidateNameDB() const
     for (const auto& name : namesInDB)
         if (namesInUTXO.count(name) == 0)
             return error("%s : name '%s' in DB but not UTXO set",
-                         __func__, ValtypeToString(name).c_str());
+                         __func__, EncodeNameForMessage(name));
     for (const auto& name : namesInUTXO)
         if (namesInDB.count(name) == 0)
             return error("%s : name '%s' in UTXO set but not DB",
-                         __func__, ValtypeToString(name).c_str());
+                         __func__, EncodeNameForMessage(name));
 
     if (fNameHistory)
     {
         for (const auto& name : namesWithHistory)
             if (nameHeightsData.count(name) == 0)
                 return error("%s : history entry for name '%s' not in main DB",
-                             __func__, ValtypeToString(name).c_str());
+                             __func__, EncodeNameForMessage(name));
     } else if (!namesWithHistory.empty ())
         return error("%s : name_history entries in DB, but"
                      " -namehistory not set", __func__);

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -304,4 +304,12 @@ extern const UniValue NullUniValue;
 
 const UniValue& find_value( const UniValue& obj, const std::string& name);
 
+/**
+ * Verifies whether a given string consists only of valid UTF-8 code points
+ * as per the JSONUTF8StringFilter.
+ *
+ * This method is exposed for Namecoin to validate names/values.
+ */
+bool IsValidUtf8String(const std::string& str);
+
 #endif // __UNIVALUE_H__

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #include "univalue.h"
+#include "univalue_utffilter.h"
 
 using namespace std;
 
@@ -242,3 +243,11 @@ const UniValue& find_value(const UniValue& obj, const std::string& name)
     return NullUniValue;
 }
 
+bool IsValidUtf8String(const std::string& str)
+{
+    std::string valStr;
+    JSONUTF8StringFilter writer(valStr);
+    for (size_t i = 0; i < str.size (); ++i)
+        writer.push_back(str[i]);
+    return writer.finalize();
+}

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -420,7 +420,7 @@ name_new (const JSONRPCRequest& request)
   const std::string randStr = HexStr (rand);
   const std::string txid = tx->GetHash ().GetHex ();
   LogPrintf ("name_new: name=%s, rand=%s, tx=%s\n",
-             ValtypeToString (name), randStr.c_str (), txid.c_str ());
+             EncodeNameForMessage (name), randStr.c_str (), txid.c_str ());
 
   UniValue res(UniValue::VARR);
   res.push_back (txid);
@@ -735,7 +735,7 @@ sendtoname (const JSONRPCRequest& request)
   if (!pcoinsTip->GetName (name, data))
     {
       std::ostringstream msg;
-      msg << "name not found: '" << ValtypeToString (name) << "'";
+      msg << "name not found: " << EncodeNameForMessage (name);
       throw JSONRPCError (RPC_INVALID_ADDRESS_OR_KEY, msg.str ());
     }
   if (data.isExpired ())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -15,6 +15,7 @@
 #include <key_io.h>
 #include <keystore.h>
 #include <validation.h>
+#include <names/encoding.h>
 #include <net.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -1680,7 +1681,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
         if (nameOp.isNameOp())
         {
             if (nameOp.isAnyUpdate())
-                output.nameOp = "update: " + ValtypeToString(nameOp.getOpName());
+                output.nameOp = "update: " + EncodeNameForMessage(nameOp.getOpName());
             else
                 output.nameOp = "new: " + HexStr(nameOp.getOpHash());
             output.amount = 0;

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -321,8 +321,10 @@ class RESTTest (BitcoinTestFramework):
         self.nodes[0].name_firstupdate(name, newData[1], newData[0], hexValue)
         self.nodes[0].generate(5)
         nameData = self.nodes[0].name_show(name)
+        assert_equal(nameData['name_encoding'], 'ascii')
         assert_equal(nameData['name'], name)
-        assert_equal(nameData['value'], value)
+        assert_equal(nameData['value_encoding'], 'hex')
+        assert_equal(nameData['value'], hexValue)
         # The REST interface explicitly does not include the 'ismine' field
         # that the RPC interface has.  Thus remove the field for the comparison
         # below.

--- a/test/functional/name_encodings.py
+++ b/test/functional/name_encodings.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the name/value encoding options in the RPC interface.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+from decimal import Decimal
+
+
+def strToHex (string):
+  return bytes_to_hex_str (string.encode ('latin1'))
+
+
+class NameEncodingsTest (NameTestFramework):
+
+  # A basic name that is valid as ASCII and used for tests with differently
+  # encoded values.
+  name = "d/test"
+
+  # A basic value that is valid as ASCII and used for tests where the
+  # name is encoded.
+  value = "test-value"
+
+  # Running counter.  This is used to compute a suffix for registered names
+  # to make sure they do not clash with names of previous tests.
+  nameCounter = 0
+
+  # Keep track of the currently set encodings.
+  nameEncoding = 'ascii'
+  valueEncoding = 'ascii'
+
+  def set_test_params (self):
+    # We need -namehistory for the test, so use node 1.  Thus we have to
+    # have two nodes here.
+    self.setup_name_test ([[]] * 2)
+
+  def setEncodings (self, nameEnc='ascii', valueEnc='ascii'):
+    args = ["-nameencoding=%s" % nameEnc, "-valueencoding=%s" % valueEnc]
+    self.restart_node (1, extra_args=args)
+
+    self.nameEncoding = nameEnc
+    self.valueEncoding = valueEnc
+
+  def uniqueName (self, baseName, enc='ascii'):
+    """
+    Uses the running nameCounter to change the baseName into a unique
+    name by adding some suffix (depending on the encoding).  The suffix
+    will be valid for the encoding, so that a valid name stays valid and
+    an invalid name is still invalid (due to the baseName itself).
+    """
+
+    suff = "%09d" % self.nameCounter
+    if enc == 'hex':
+      suff = strToHex (suff)
+
+    self.nameCounter += 1
+
+    return baseName + suff
+
+  def nameRawTx (self, nameInp, nameOp):
+    """
+    Constructs, signs and sends a raw transaction using namerawtransaction
+    with the given (if any) previous name input.
+
+    Returned are the result of namerawtransaction (for name_new), to which the
+    final txid and name vout are added.
+    """
+
+    ins = []
+    if nameInp is not None:
+      ins.append ({"txid": nameInp['txid'], "vout": nameInp['vout']})
+    addr = self.node.getnewaddress ()
+    out = {addr: Decimal ('0.01')}
+
+    rawTx = self.node.createrawtransaction (ins, out)
+    nameOpData = self.node.namerawtransaction (rawTx, 0, nameOp)
+
+    rawTx = self.node.fundrawtransaction (nameOpData['hex'])['hex']
+    vout = self.rawtxOutputIndex (1, rawTx, addr)
+    assert vout is not None
+
+    signed = self.node.signrawtransactionwithwallet (rawTx)
+    assert signed['complete']
+    txid = self.node.sendrawtransaction (signed['hex'])
+
+    nameOpData['txid'] = txid
+    nameOpData['vout'] = vout
+    return nameOpData
+
+  def verifyAndMinePendingUpdate (self, name, value, txid):
+    """
+    Verifies that there is a pending transaction that (first)updates
+    name to value with the given txid.  The tx is mined as well, and then
+    all the read-only RPCs are checked for it (name_show, name_list, ...).
+    """
+
+    data = self.node.name_pending (name)
+    assert_equal (len (data), 1)
+    # FIXME: Reenable once the output is also in the requested encoding.
+    #assert_equal (data[0]['name'], name)
+    #assert_equal (data[0]['value'], value)
+    assert_equal (data[0]['txid'], txid)
+
+    self.node.generate (1)
+    data = self.node.name_show (name)
+    #assert_equal (data['name'], name)
+    #assert_equal (data['value'], value)
+    assert_equal (data['txid'], txid)
+
+    assert_equal (self.node.name_history (name)[-1], data)
+    assert_equal (self.node.name_scan (name, 1)[0], data)
+    assert_equal (self.node.name_list (name)[0], data)
+
+    found = False
+    for d in self.node.name_filter ():
+      if d['txid'] == txid:
+        assert_equal (d, data)
+        assert not found
+        found = True
+    assert found
+
+  def validName (self, baseName, encoding):
+    """
+    Runs tests asserting that the given string is valid as name in the
+    given encoding.
+    """
+
+    self.setEncodings (nameEnc=encoding)
+
+    name = self.uniqueName (baseName, encoding)
+    new = self.node.name_new (name)
+    self.node.generate (1)
+    txid = self.firstupdateName (1, name, new, self.value)
+    self.node.generate (11)
+    self.verifyAndMinePendingUpdate (name, self.value, txid)
+
+    txid = self.node.name_update (name, self.value)
+    self.verifyAndMinePendingUpdate (name, self.value, txid)
+
+    # FIXME: Once the output-side has configurable encoding, we should
+    # also cross-check the result of name_show against a different encoding
+    # to make sure the resulting names are indeed correct.
+
+    self.node.sendtoname (name, 1)
+
+    # Redo the whole life-cycle now also with raw transactions (with a new
+    # unique name).
+    name = self.uniqueName (baseName, encoding)
+
+    new = self.nameRawTx (None, {
+      "op": "name_new",
+      "name": name,
+    })
+    self.node.generate (1)
+    first = self.nameRawTx (new, {
+      "op": "name_firstupdate",
+      "name": name,
+      "value": self.value,
+      "rand": new['rand'],
+    })
+    self.node.generate (11)
+    self.verifyAndMinePendingUpdate (name, self.value, first['txid'])
+
+    upd = self.nameRawTx (first, {
+      "op": "name_update",
+      "name": name,
+      "value": self.value,
+    })
+    self.verifyAndMinePendingUpdate (name, self.value, upd['txid'])
+
+  def validValue (self, value, encoding):
+    """
+    Runs tests asserting that the given string is valid as value in the
+    given encoding.
+    """
+
+    self.setEncodings (valueEnc=encoding)
+
+    name = self.uniqueName (self.name, encoding)
+    new = self.node.name_new (name)
+    self.node.generate (1)
+    txid = self.firstupdateName (1, name, new, value)
+    self.node.generate (11)
+    self.verifyAndMinePendingUpdate (name, value, txid)
+
+    txid = self.node.name_update (name, value)
+    self.verifyAndMinePendingUpdate (name, value, txid)
+
+    # Redo the whole life-cycle now also with raw transactions (with a new
+    # unique name).
+    name = self.uniqueName (self.name, encoding)
+
+    new = self.nameRawTx (None, {
+      "op": "name_new",
+      "name": name,
+    })
+    self.node.generate (1)
+    first = self.nameRawTx (new, {
+      "op": "name_firstupdate",
+      "name": name,
+      "value": value,
+      "rand": new['rand'],
+    })
+    self.node.generate (11)
+    self.verifyAndMinePendingUpdate (name, value, first['txid'])
+
+    upd = self.nameRawTx (first, {
+      "op": "name_update",
+      "name": name,
+      "value": value,
+    })
+    self.verifyAndMinePendingUpdate (name, value, upd['txid'])
+
+  def invalidName (self, name, encoding):
+    """
+    Runs tests to check that the various RPC methods treat the given name
+    as invalid in the encoding.
+    """
+
+    self.setEncodings (nameEnc=encoding)
+
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_new, name)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_firstupdate,
+                             name, "00", 32 * "00", self.value)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_update, name, self.value)
+
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_pending, name)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_show, name)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_history, name)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_scan, name)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_list, name)
+
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.sendtoname, name, 1)
+
+    nameNew = {
+      "op": "name_new",
+      "name": name,
+    }
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.nameRawTx, None, nameNew)
+    nameFirst = {
+      "op": "name_firstupdate",
+      "name": name,
+      "value": self.value,
+      "rand": "00",
+    }
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.nameRawTx, None, nameFirst)
+    nameUpd = {
+      "op": "name_update",
+      "name": name,
+      "value": self.value,
+    }
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.nameRawTx, None, nameUpd)
+
+  def invalidValue (self, value, encoding):
+    """
+    Runs tests to check that the various RPC methods treat the given value
+    as invalid in the encoding.
+    """
+
+    self.setEncodings (valueEnc=encoding)
+
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_firstupdate,
+                             self.name, "00", 32 * "00", value)
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.node.name_update, self.name, value)
+
+    nameFirst = {
+      "op": "name_firstupdate",
+      "name": self.name,
+      "value": value,
+      "rand": "00",
+    }
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.nameRawTx, None, nameFirst)
+    nameUpd = {
+      "op": "name_update",
+      "name": self.name,
+      "value": value,
+    }
+    assert_raises_rpc_error (-1000, "Name/value is invalid",
+                             self.nameRawTx, None, nameUpd)
+
+  def run_test (self):
+    self.node = self.nodes[1]
+
+    # Note:  The tests here are mainly important to verify that strings
+    # are encoded/decoded at all.  The different possibilities for valid
+    # and invalid strings in detail are tested already in the unit test.
+    # But since we have the utility methods available, we might just as well
+    # call them with different values instead of just once or twice.
+
+    self.validName ("d/abc", "ascii")
+    self.validName ("d/\x00äöü\n", "utf8")
+    # FIXME: Use some hex that is invalid UTF-8 once the output-side has been
+    # fixed to not write invalid UTF-8 JSON that then fails in the RPC client.
+    self.validName ("00117f", "hex")
+
+    self.validValue ('{"foo":"bar"}', "ascii")
+    self.validValue ('{"foo":"\x00äöü\n"}', "utf8")
+    self.validValue (strToHex ('{"foo":"\x00\x7f"}'), "hex")
+
+    self.invalidName ("d/\n", "ascii")
+    self.invalidName ("d/äöü", "ascii")
+    self.invalidName ("d/\xff", "ascii")
+    # We cannot actually test invalid UTF-8, because a string with arbitrary
+    # bytes gets UTF-8 encoded when sending to JSON RPC.
+    self.invalidName ("", "hex")
+    self.invalidName ("d", "hex")
+    self.invalidName ("xx", "hex")
+
+    self.invalidValue ('{"foo":"\n"}', "ascii")
+    self.invalidValue ('{"foo":"äöü"}', "ascii")
+    self.invalidValue ('{"foo":"\xff"}', "ascii")
+    self.invalidValue ('', "hex")
+    self.invalidValue ('d', "hex")
+    self.invalidValue ('xx', "hex")
+
+
+if __name__ == '__main__':
+  NameEncodingsTest ().main ()

--- a/test/functional/name_wallet.py
+++ b/test/functional/name_wallet.py
@@ -140,9 +140,9 @@ class NameWalletTest (NameTestFramework):
     self.checkTx (2, newA[0], zero, -newFee,
                   [['send', 'new', zero, -newFee]])
     self.checkTx (2, firstA, zero, -firstFee,
-                  [['send', 'update: name-a', zero, -firstFee]])
+                  [['send', "update: 'name-a'", zero, -firstFee]])
     self.checkTx (2, updA, zero, -updFee,
-                  [['send', 'update: name-a', zero, -updFee]])
+                  [['send', "update: 'name-a'", zero, -updFee]])
 
     # Send a name from 1 to 2 by firstupdate and update.
     addrB = self.nodes[3].getnewaddress ()
@@ -167,9 +167,9 @@ class NameWalletTest (NameTestFramework):
 
     # Check the receiving transactions on B.
     self.checkTx (3, firstB, zero, None,
-                  [['receive', 'update: name-b', zero, None]])
+                  [['receive', "update: 'name-b'", zero, None]])
     self.checkTx (3, updC, zero, None,
-                  [['receive', 'update: name-c', zero, None]])
+                  [['receive', "update: 'name-c'", zero, None]])
 
     # Use the rawtx API to build a simultaneous name update and currency send.
     # This is done as an atomic name trade.  Note, though, that the
@@ -186,7 +186,7 @@ class NameWalletTest (NameTestFramework):
                   [['receive', "none", price, None]])
     self.checkTx (3, txid, -price, -fee,
                   [['send', "none", -price, -fee],
-                   ['send', 'update: name-a', zero, -fee]])
+                   ['send', "update: 'name-a'", zero, -fee]])
 
     # Test sendtoname RPC command.
 

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "\nName and value encodings..."
+./name_encodings.py
+
 echo "\nName expiration..."
 ./name_expiration.py
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -165,6 +165,7 @@ BASE_SCRIPTS = [
     'auxpow_mining.py --segwit',
 
     # name tests
+    'name_encodings.py',
     'name_expiration.py',
     'name_immature_inputs.py',
     'name_ismine.py',

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -514,5 +514,16 @@
     "return_code": 1,
     "error_txt": "error: nameupdate expects N:NAME:VALUE",
     "description": "Verify the number of arguments check for nameupdate"
+  },
+  { "exec": "./namecoin-tx",
+    "args":
+    ["-create",
+     "-json",
+     "-nameencoding=ascii",
+     "-valueencoding=hex",
+     "outaddr=0.01:MyUGVwiPwomjPJwBBud1pxnmNp73dKB9s1",
+     "nameupdate=0:642f00ff:76616c7565"],
+    "output_cmp": "name_update_encoding.json",
+    "description": "Outputs NAME_UPDATE transaction to JSON with specified encodings"
   }
 ]

--- a/test/util/data/name_update_encoding.json
+++ b/test/util/data/name_update_encoding.json
@@ -1,0 +1,34 @@
+{
+    "txid": "6546af17efa73666d4c1c43a485897524512950db88f94374f8678d04191d1d7",
+    "hash": "6546af17efa73666d4c1c43a485897524512950db88f94374f8678d04191d1d7",
+    "version": 1,
+    "size": 58,
+    "vsize": 58,
+    "weight": 232,
+    "locktime": 0,
+    "vin": [
+    ],
+    "vout": [
+        {
+            "value": 0.01000000,
+            "n": 0,
+            "scriptPubKey": {
+                "nameOp": {
+                    "op": "name_update",
+                    "name_error": "invalid data for ascii",
+                    "name_encoding": "ascii",
+                    "value": "76616c7565",
+                    "value_encoding": "hex"
+                },
+                "asm": "OP_NAME_UPDATE 642f00ff 76616c7565 OP_2DROP OP_DROP OP_DUP OP_HASH160 1fc11f39be1729bf973a7ab6a615ca4729d64574 OP_EQUALVERIFY OP_CHECKSIG",
+                "hex": "5304642f00ff0576616c75656d7576a9141fc11f39be1729bf973a7ab6a615ca4729d6457488ac",
+                "reqSigs": 1,
+                "type": "pubkeyhash",
+                "addresses": [
+                    "MyUGVwiPwomjPJwBBud1pxnmNp73dKB9s1"
+                ]
+            }
+        }
+    ],
+    "hex": "01000000000140420f0000000000275304642f00ff0576616c75656d7576a9141fc11f39be1729bf973a7ab6a615ca4729d6457488ac00000000"
+}


### PR DESCRIPTION
This implements the main part of the proposal in #246:  New `-nameencoding` and `-valueencoding` options are added, with the possible values of `ascii`, `utf8` and `hex`.  They specify in which encoding name and value data is expected in RPC arguments and returned in JSON fields.  This fixes a long-standing issue Namecoin had with binary data that was invalid UTF-8 (as well as adding proper support for real binary data in the RPC interface).  As a consequence, this likely resolves (or is at least a big part of the solution of) #152 and #170.

Still missing for a full solution of #246 is the possibility to specify per-RPC encodings in an `options` RPC argument.  For now, the encodings can only be set for the full process at startup time through the config options.