### PR TITLE
Handle names for gettxoutsetinfo

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -22,6 +22,7 @@
 #include <rpc/rawtransaction.h>
 #include <rpc/server.h>
 #include <script/descriptor.h>
+#include <script/names.h>
 #include <streams.h>
 #include <sync.h>
 #include <txdb.h>
@@ -887,9 +888,10 @@ struct CCoinsStats
     uint64_t nBogoSize;
     uint256 hashSerialized;
     uint64_t nDiskSize;
-    CAmount nTotalAmount;
+    CAmount nCoinAmount;
+    CAmount nNameAmount;
 
-    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nBogoSize(0), nDiskSize(0), nTotalAmount(0) {}
+    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nBogoSize(0), nDiskSize(0), nCoinAmount(0), nNameAmount(0) {}
 };
 
 static void ApplyStats(CCoinsStats &stats, CHashWriter& ss, const uint256& hash, const std::map<uint32_t, Coin>& outputs)
@@ -903,7 +905,14 @@ static void ApplyStats(CCoinsStats &stats, CHashWriter& ss, const uint256& hash,
         ss << output.second.out.scriptPubKey;
         ss << VARINT(output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
         stats.nTransactionOutputs++;
-        stats.nTotalAmount += output.second.out.nValue;
+
+        const CNameScript nameOp(output.second.out.scriptPubKey);
+        if (nameOp.isNameOp()) {
+            stats.nNameAmount += output.second.out.nValue;
+        } else {
+            stats.nCoinAmount += output.second.out.nValue;
+        }
+
         stats.nBogoSize += 32 /* txid */ + 4 /* vout index */ + 4 /* height + coinbase */ + 8 /* amount */ +
                            2 /* scriptPubKey len */ + output.second.out.scriptPubKey.size() /* scriptPubKey */;
     }
@@ -1014,7 +1023,11 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
             "  \"bogosize\": n,          (numeric) A meaningless metric for UTXO set size\n"
             "  \"hash_serialized_2\": \"hash\", (string) The serialized hash\n"
             "  \"disk_size\": n,         (numeric) The estimated size of the chainstate on disk\n"
-            "  \"total_amount\": x.xxx          (numeric) The total amount\n"
+            "  \"total_amount\": {       (json object)\n"
+            "    \"coins\": x.xxx,       (numeric) Total amount of coins\n"
+            "    \"names\": x.xxx,       (numeric) Amount locked in active names\n"
+            "    \"total\": x.xxx        (numeric) Total amount in coins and names\n"
+            "  }\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("gettxoutsetinfo", "")
@@ -1033,7 +1046,12 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
         ret.pushKV("bogosize", (int64_t)stats.nBogoSize);
         ret.pushKV("hash_serialized_2", stats.hashSerialized.GetHex());
         ret.pushKV("disk_size", stats.nDiskSize);
-        ret.pushKV("total_amount", ValueFromAmount(stats.nTotalAmount));
+
+        UniValue amount(UniValue::VOBJ);
+        amount.pushKV("coins", ValueFromAmount(stats.nCoinAmount));
+        amount.pushKV("names", ValueFromAmount(stats.nNameAmount));
+        amount.pushKV("total", ValueFromAmount(stats.nCoinAmount + stats.nNameAmount));
+        ret.pushKV("amount", amount);
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
     }

--- a/test/functional/name_utxo.py
+++ b/test/functional/name_utxo.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the interaction between names and the UTXO set.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+
+class NameUtxoTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 1)
+
+  def run_test (self):
+    node = self.nodes[0]
+
+    # Prepare the scene:  We want one stale name_new, one expired name
+    # and one unexpired name.
+
+    addr = node.getnewaddress ()
+    newStale = node.name_new ("d/never-registered", {"destAddress": addr})
+    txidStale = newStale[0]
+    txStale = node.getrawtransaction (txidStale)
+    voutStale = self.rawtxOutputIndex (0, txStale, addr)
+
+    newExpired = node.name_new ("d/expired")
+    newActive = node.name_new ("d/active")
+    node.generate (10)
+    self.firstupdateName (0, "d/expired", newExpired, "{}")
+    node.generate (20)
+    self.firstupdateName (0, "d/active", newActive, "{}")
+    node.generate (20)
+
+    # The never used name_new should be in the UTXO set.
+    txo = node.gettxout (txidStale, voutStale)
+    assert_equal (txo['scriptPubKey']['nameOp']['op'], 'name_new')
+
+    # The expired name should *not* be in the UTXO set.
+    data = node.name_show ("d/expired")
+    assert_equal (data['expired'], True)
+    assert_equal (node.gettxout (data['txid'], data['vout']), None)
+
+    # The active name should be there.
+    data = node.name_show ("d/active")
+    assert_equal (data['expired'], False)
+    txo = node.gettxout (data['txid'], data['vout'])
+    nameOp = txo['scriptPubKey']['nameOp']
+    assert_equal (nameOp['op'], 'name_firstupdate')
+    assert_equal (nameOp['name'], 'd/active')
+
+    # Verify the expected result for gettxoutsetinfo.  The unused name_new
+    # should be in there, as well as the active name.  The expired name
+    # should be removed from it (as tested already above).
+    data = node.gettxoutsetinfo ()
+    height = data['height']
+    assert_equal (height, 250)
+    assert_equal (data['txouts'], 252)
+    amount = data['amount']
+    assert_equal (amount['names'], Decimal ('0.02'))
+    assert_equal (amount['total'], amount['names'] + amount['coins'])
+    mined = 149 * 50 + (height - 149) * 25
+    assert_equal (amount['total'], mined - Decimal ('0.01'))
+
+
+if __name__ == '__main__':
+  NameUtxoTest ().main ()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -165,7 +165,7 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res['total_amount'], Decimal('8725.00000000'))
+        assert_equal(res['amount']['total'], Decimal('8725.00000000'))
         assert_equal(res['transactions'], 200)
         assert_equal(res['height'], 200)
         assert_equal(res['txouts'], 200)
@@ -183,7 +183,7 @@ class BlockchainTest(BitcoinTestFramework):
 
         res2 = node.gettxoutsetinfo()
         assert_equal(res2['transactions'], 0)
-        assert_equal(res2['total_amount'], Decimal('0'))
+        assert_equal(res2['amount']['total'], Decimal('0'))
         assert_equal(res2['height'], 0)
         assert_equal(res2['txouts'], 0)
         assert_equal(res2['bogosize'], 0),
@@ -194,7 +194,7 @@ class BlockchainTest(BitcoinTestFramework):
         node.reconsiderblock(b1hash)
 
         res3 = node.gettxoutsetinfo()
-        assert_equal(res['total_amount'], res3['total_amount'])
+        assert_equal(res['amount'], res3['amount'])
         assert_equal(res['transactions'], res3['transactions'])
         assert_equal(res['height'], res3['height'])
         assert_equal(res['txouts'], res3['txouts'])

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -39,5 +39,8 @@ echo "\nName scanning..."
 echo "\nName operation with sendCoins..."
 ./name_sendcoins.py
 
+echo "\nNames and the UTXO set..."
+./name_utxo.py
+
 echo "\nName wallet..."
 ./name_wallet.py

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -179,6 +179,7 @@ BASE_SCRIPTS = [
     'name_reorg.py',
     'name_scanning.py',
     'name_sendcoins.py',
+    'name_utxo.py',
     'name_wallet.py',
 ]
 


### PR DESCRIPTION
Add explicit logic to `gettxoutsetinfo` that separates the amounts locked in names from the amounts available in coins.  Also adds a new regtest specifically for the interaction of names with the UTXO set.

This fixes https://github.com/namecoin/namecoin-core/issues/251.