### PR TITLE
queuerawtransaction and listqueuedtransactions

### DIFF
--- a/src/names/common.h
+++ b/src/names/common.h
@@ -5,10 +5,12 @@
 #ifndef H_BITCOIN_NAMES_COMMON
 #define H_BITCOIN_NAMES_COMMON
 
+#include <base58.h>
 #include <compat/endian.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <serialize.h>
+#include <uint256.h>
 
 #include <map>
 #include <set>
@@ -444,6 +446,44 @@ public:
   /* Write all cached changes to a database batch update object.  */
   void writeBatch (CDBBatch& batch) const;
 
+};
+
+/* ************************************************************************** */
+/* CQueuedTransaction.  */
+
+/**
+ * Keeps track of raw transactions that are queued for later broadcast.
+ * Example use cases:
+ *     Broadcast a name_firstupdate when its input name_new reaches maturity.
+ *     Broadcast a name_update when its input name_anyupdate nears expiration.
+ *     Broadcast a name_firstupdate when someone else's name expires.
+ * This data is serialized to the wallet so that the transaction can be
+ * broadcasted even if the client has restarted since the transaction was
+ * queued.
+ */
+class CQueuedTransaction
+{
+private:
+    uint256 triggerTxid;
+    valtype triggerName;
+    int32_t triggerDepth;
+    valtype tx;
+
+public:
+    SERIALIZE_METHODS(CQueuedTransaction, obj)
+    {
+        READWRITE(obj.triggerTxid, obj.triggerName, obj.triggerDepth, obj.tx);
+    }
+
+    inline const uint256& getTriggerTxid() const { return triggerTxid; }
+    inline const valtype& getTriggerName() const { return triggerName; }
+    inline int32_t getTriggerDepth() const { return triggerDepth; }
+    inline const valtype& getTx() const { return tx; }
+
+    inline void setTriggerTxid(const uint256& val) { triggerTxid = val; }
+    inline void setTriggerName(const valtype& val) { triggerName = val; }
+    inline void setTriggerDepth(const int32_t& val) { triggerDepth = val; }
+    inline void setTx(const valtype& val) { tx = val; }
 };
 
 #endif // H_BITCOIN_NAMES_COMMON

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -168,6 +168,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "name_update", 2, "options" },
     { "namerawtransaction", 1, "vout" },
     { "namerawtransaction", 2, "nameop" },
+    { "queuerawtransaction", 1, "options" },
     { "sendtoname", 1, "amount" },
     { "sendtoname", 4, "subtractfeefromamount" },
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -752,7 +752,11 @@ std::string RPCArg::ToStringObj(const bool oneline) const
             res += i.ToString(oneline) + ",";
         }
         return res + "...]";
-    case Type::OBJ:
+    case Type::OBJ: {
+        // Used in Namecoin by queuerawtransaction; unused in Bitcoin.
+        const std::string res_inner = Join(m_inner, ",", [&](const RPCArg& i) { return i.ToStringObj(oneline); });
+        return res + "{" + res_inner + "}";
+    }
     case Type::OBJ_USER_KEYS:
         // Currently unused, so avoid writing dead code
         CHECK_NONFATAL(false);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4352,6 +4352,7 @@ extern UniValue name_new(const JSONRPCRequest& request);
 extern UniValue name_firstupdate(const JSONRPCRequest& request);
 extern UniValue name_update(const JSONRPCRequest& request);
 extern UniValue queuerawtransaction (const JSONRPCRequest& request);
+extern UniValue listqueuedtransactions (const JSONRPCRequest& request);
 extern UniValue sendtoname(const JSONRPCRequest& request);
 
 Span<const CRPCCommand> GetWalletRPCCommands()
@@ -4428,6 +4429,7 @@ static const CRPCCommand commands[] =
     { "names",              "name_firstupdate",                 &name_firstupdate,              {"name","rand","tx","value","options","allow_active"} },
     { "names",              "name_update",                      &name_update,                   {"name","value","options"} },
     { "names",              "queuerawtransaction",              &queuerawtransaction,           {"hexstring","options"} },
+    { "names",              "listqueuedtransactions",           &listqueuedtransactions,        {} },
     { "names",              "sendtoname",                       &sendtoname,                    {"name","amount","comment","comment_to","subtractfeefromamount"} },
 };
 // clang-format on

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4351,6 +4351,7 @@ extern UniValue name_list(const JSONRPCRequest& request); // in rpcnames.cpp
 extern UniValue name_new(const JSONRPCRequest& request);
 extern UniValue name_firstupdate(const JSONRPCRequest& request);
 extern UniValue name_update(const JSONRPCRequest& request);
+extern UniValue queuerawtransaction (const JSONRPCRequest& request);
 extern UniValue sendtoname(const JSONRPCRequest& request);
 
 Span<const CRPCCommand> GetWalletRPCCommands()
@@ -4426,6 +4427,7 @@ static const CRPCCommand commands[] =
     { "names",              "name_new",                         &name_new,                      {"name","options"} },
     { "names",              "name_firstupdate",                 &name_firstupdate,              {"name","rand","tx","value","options","allow_active"} },
     { "names",              "name_update",                      &name_update,                   {"name","value","options"} },
+    { "names",              "queuerawtransaction",              &queuerawtransaction,           {"hexstring","options"} },
     { "names",              "sendtoname",                       &sendtoname,                    {"name","amount","comment","comment_to","subtractfeefromamount"} },
 };
 // clang-format on

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -9,6 +9,7 @@
 #include <amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <names/common.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <psbt.h>
@@ -1287,6 +1288,18 @@ public:
 
     //! Add a descriptor to the wallet, return a ScriptPubKeyMan & associated output type
     ScriptPubKeyMan* AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label);
+
+    std::map<std::string, CQueuedTransaction> queuedTransactionMap;
+
+    bool QueuedTransactionExists(const std::string &name);
+    bool WriteQueuedTransaction(
+            const std::string &name,
+            const valtype &tx,
+            const uint256 &triggerTxid,
+            const valtype &triggerName,
+            const int32_t &triggerDepth);
+    bool EraseQueuedTransaction(const std::string &name);
+    bool GetQueuedTransaction(const std::string &name, CQueuedTransaction *data=nullptr);
 };
 
 /**

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <amount.h>
+#include <names/common.h>
 #include <script/sign.h>
 #include <wallet/bdb.h>
 #include <wallet/db.h>
@@ -254,6 +255,9 @@ public:
     bool EraseDestData(const std::string &address, const std::string &key);
 
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
+
+    bool WriteQueuedTransaction(const std::string& name, const CQueuedTransaction& data);
+    bool EraseQueuedTransaction(const std::string& name);
 
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);


### PR DESCRIPTION
This PR implements `queuerawtransaction` and `listqueuedtransactions` as described in https://github.com/namecoin/namecoin-core/issues/233 .  The other RPC calls from that issue are left for a future PR.

Code quality may not be Daniel-quality, since I'm not particularly familiar with the Namecoin Core codebase -- feel free to suggest improvements.  The database-related changes are heavily based on @brandonrobertz 's code.