### PR TITLE
Fix for names and native segwit + tests

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -76,6 +76,7 @@ BITCOIN_TESTS =\
   test/scheduler_tests.cpp \
   test/script_p2sh_tests.cpp \
   test/script_tests.cpp \
+  test/script_segwit_tests.cpp \
   test/script_standard_tests.cpp \
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -38,7 +38,7 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
     int witnessversion = 0;
     std::vector<unsigned char> witnessprogram;
 
-    if (txout.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
+    if (txout.scriptPubKey.IsWitnessProgram(true, witnessversion, witnessprogram)) {
         // sum the sizes of the parts of a transaction input
         // with 75% segwit discount applied to the script size.
         nSize += (32 + 4 + 1 + (107 / WITNESS_SCALE_FACTOR) + 4);
@@ -222,7 +222,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         std::vector<unsigned char> witnessprogram;
 
         // Non-witness program must not be associated with any witness
-        if (!prevScript.IsWitnessProgram(witnessversion, witnessprogram))
+        if (!prevScript.IsWitnessProgram(true, witnessversion, witnessprogram))
             return false;
 
         // Check P2WSH standard limits

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -463,7 +463,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         CTxDestination address;
         int witnessversion = 0;
         std::vector<unsigned char> witnessprogram;
-        if (out.txout.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram))
+        if (out.txout.scriptPubKey.IsWitnessProgram(true, witnessversion, witnessprogram))
         {
             nBytesInputs += (32 + 4 + 1 + (107 / WITNESS_SCALE_FACTOR) + 4);
             fWitness = true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1499,7 +1499,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     int witnessversion;
     std::vector<unsigned char> witnessprogram;
     if (flags & SCRIPT_VERIFY_WITNESS) {
-        if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
+        if (scriptPubKey.IsWitnessProgram(true, witnessversion, witnessprogram)) {
             hadWitness = true;
             if (scriptSig.size() != 0) {
                 // The scriptSig must be _exactly_ CScript(), otherwise we reintroduce malleability.
@@ -1543,7 +1543,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 
         // P2SH witness program
         if (flags & SCRIPT_VERIFY_WITNESS) {
-            if (pubKey2.IsWitnessProgram(witnessversion, witnessprogram)) {
+            if (pubKey2.IsWitnessProgram(true, witnessversion, witnessprogram)) {
                 hadWitness = true;
                 if (scriptSig != CScript() << std::vector<unsigned char>(pubKey2.begin(), pubKey2.end())) {
                     // The scriptSig must be _exactly_ a single push of the redeemScript. Otherwise we
@@ -1613,7 +1613,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
 
     int witnessversion;
     std::vector<unsigned char> witnessprogram;
-    if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
+    if (scriptPubKey.IsWitnessProgram(true, witnessversion, witnessprogram)) {
         return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty);
     }
 
@@ -1625,7 +1625,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
             scriptSig.GetOp(pc, opcode, data);
         }
         CScript subscript(data.begin(), data.end());
-        if (subscript.IsWitnessProgram(witnessversion, witnessprogram)) {
+        if (subscript.IsWitnessProgram(true, witnessversion, witnessprogram)) {
             return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty);
         }
     }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -224,8 +224,16 @@ bool CScript::IsPayToWitnessScriptHash(bool allowNames) const
 
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
-bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const
+bool CScript::IsWitnessProgram(const bool allowNames, int& version, std::vector<unsigned char>& program) const
 {
+    // Strip off a name prefix if present.
+    if (allowNames)
+      {
+        const CNameScript nameOp(*this);
+        return nameOp.getAddress().IsWitnessProgram(false, version, program);
+      }
+
+    // Handle the case without name prefix.
     if (this->size() < 4 || this->size() > 42) {
         return false;
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -548,7 +548,7 @@ public:
      */
     bool IsPayToScriptHash(bool allowNames) const;
     bool IsPayToWitnessScriptHash(bool allowNames) const;
-    bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
+    bool IsWitnessProgram(bool allowNames, int& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -105,7 +105,7 @@ txnouttype Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned 
 
     int witnessversion;
     std::vector<unsigned char> witnessprogram;
-    if (script.IsWitnessProgram(witnessversion, witnessprogram)) {
+    if (script.IsWitnessProgram(false, witnessversion, witnessprogram)) {
         if (witnessversion == 0 && witnessprogram.size() == WITNESS_V0_KEYHASH_SIZE) {
             vSolutionsRet.push_back(witnessprogram);
             return TX_WITNESS_V0_KEYHASH;

--- a/src/test/script_segwit_tests.cpp
+++ b/src/test/script_segwit_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <script/names.h>
 #include <script/script.h>
 #include <test/test_bitcoin.h>
 
@@ -14,11 +15,11 @@ BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Valid)
     uint256 dummy;
     CScript p2wsh;
     p2wsh << OP_0 << ToByteVector(dummy);
-    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash());
+    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash(false));
 
     std::vector<unsigned char> bytes = {OP_0, 32};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+    BOOST_CHECK(CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash(false));
 }
 
 BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_NotOp0)
@@ -26,7 +27,7 @@ BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_NotOp0)
     uint256 dummy;
     CScript notp2wsh;
     notp2wsh << OP_1 << ToByteVector(dummy);
-    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash (false));
 }
 
 BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Size)
@@ -34,7 +35,7 @@ BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Size)
     uint160 dummy;
     CScript notp2wsh;
     notp2wsh << OP_0 << ToByteVector(dummy);
-    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash (false));
 }
 
 BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Nop)
@@ -42,13 +43,13 @@ BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Nop)
     uint256 dummy;
     CScript notp2wsh;
     notp2wsh << OP_0 << OP_NOP << ToByteVector(dummy);
-    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash (false));
 }
 
 BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_EmptyScript)
 {
     CScript notp2wsh;
-    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash (false));
 }
 
 BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Pushdata)
@@ -56,24 +57,41 @@ BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Pushdata)
     // A script is not P2WSH if OP_PUSHDATA is used to push the hash.
     std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash(false));
 
     bytes = {OP_0, OP_PUSHDATA2, 32, 0};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash(false));
 
     bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash(false));
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_NamePrefix)
+{
+    uint256 dummy;
+    CScript p2wsh;
+    p2wsh << OP_0 << ToByteVector(dummy);
+
+    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash(true));
+    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash(false));
+
+    const valtype name(10, 'a');
+    const valtype value(20, 'b');
+    const CScript nameP2WSH = CNameScript::buildNameUpdate(p2wsh, name, value);
+
+    BOOST_CHECK(nameP2WSH.IsPayToWitnessScriptHash(true));
+    BOOST_CHECK(!nameP2WSH.IsPayToWitnessScriptHash(false));
 }
 
 namespace {
 
-bool IsExpectedWitnessProgram(const CScript& script, const int expectedVersion, const std::vector<unsigned char>& expectedProgram)
+bool IsExpectedWitnessProgram(const bool allowNames, const CScript& script, const int expectedVersion, const std::vector<unsigned char>& expectedProgram)
 {
     int actualVersion;
     std::vector<unsigned char> actualProgram;
-    if (!script.IsWitnessProgram(actualVersion, actualProgram)) {
+    if (!script.IsWitnessProgram(allowNames, actualVersion, actualProgram)) {
         return false;
     }
     BOOST_CHECK_EQUAL(actualVersion, expectedVersion);
@@ -81,11 +99,11 @@ bool IsExpectedWitnessProgram(const CScript& script, const int expectedVersion, 
     return true;
 }
 
-bool IsNoWitnessProgram(const CScript& script)
+bool IsNoWitnessProgram(const bool allowNames, const CScript& script)
 {
     int dummyVersion;
     std::vector<unsigned char> dummyProgram;
-    return !script.IsWitnessProgram(dummyVersion, dummyProgram);
+    return !script.IsWitnessProgram(allowNames, dummyVersion, dummyProgram);
 }
 
 } // anonymous namespace
@@ -95,17 +113,17 @@ BOOST_AUTO_TEST_CASE(IsWitnessProgram_Valid)
     std::vector<unsigned char> program = {42, 18};
     CScript wit;
     wit << OP_0 << program;
-    BOOST_CHECK(IsExpectedWitnessProgram(wit, 0, program));
+    BOOST_CHECK(IsExpectedWitnessProgram(false, wit, 0, program));
 
     wit.clear();
     program.resize(40);
     wit << OP_16 << program;
-    BOOST_CHECK(IsExpectedWitnessProgram(wit, 16, program));
+    BOOST_CHECK(IsExpectedWitnessProgram(false, wit, 16, program));
 
     program.resize(32);
     std::vector<unsigned char> bytes = {OP_5, static_cast<unsigned char>(program.size())};
     bytes.insert(bytes.end(), program.begin(), program.end());
-    BOOST_CHECK(IsExpectedWitnessProgram(CScript(bytes.begin(), bytes.end()), 5, program));
+    BOOST_CHECK(IsExpectedWitnessProgram(false, CScript(bytes.begin(), bytes.end()), 5, program));
 }
 
 BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Version)
@@ -113,7 +131,7 @@ BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Version)
     std::vector<unsigned char> program(10);
     CScript nowit;
     nowit << OP_1NEGATE << program;
-    BOOST_CHECK(IsNoWitnessProgram(nowit));
+    BOOST_CHECK(IsNoWitnessProgram(false, nowit));
 }
 
 BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Size)
@@ -121,12 +139,12 @@ BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Size)
     std::vector<unsigned char> program(1);
     CScript nowit;
     nowit << OP_0 << program;
-    BOOST_CHECK(IsNoWitnessProgram(nowit));
+    BOOST_CHECK(IsNoWitnessProgram(false, nowit));
 
     nowit.clear();
     program.resize(41);
     nowit << OP_0 << program;
-    BOOST_CHECK(IsNoWitnessProgram(nowit));
+    BOOST_CHECK(IsNoWitnessProgram(false, nowit));
 }
 
 BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Nop)
@@ -134,13 +152,13 @@ BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Nop)
     std::vector<unsigned char> program(10);
     CScript nowit;
     nowit << OP_0 << OP_NOP << program;
-    BOOST_CHECK(IsNoWitnessProgram(nowit));
+    BOOST_CHECK(IsNoWitnessProgram(false, nowit));
 }
 
 BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_EmptyScript)
 {
     CScript nowit;
-    BOOST_CHECK(IsNoWitnessProgram(nowit));
+    BOOST_CHECK(IsNoWitnessProgram(false, nowit));
 }
 
 BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Pushdata)
@@ -148,15 +166,53 @@ BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Pushdata)
     // A script is no witness program if OP_PUSHDATA is used to push the hash.
     std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+    BOOST_CHECK(IsNoWitnessProgram(false, CScript(bytes.begin(), bytes.end())));
 
     bytes = {OP_0, OP_PUSHDATA2, 32, 0};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+    BOOST_CHECK(IsNoWitnessProgram(false, CScript(bytes.begin(), bytes.end())));
 
     bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
     bytes.insert(bytes.end(), 32, 0);
-    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+    BOOST_CHECK(IsNoWitnessProgram(false, CScript(bytes.begin(), bytes.end())));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_WithNamePrefix)
+{
+    const std::vector<unsigned char> program(20, 42);
+    CScript wit;
+    wit << OP_0 << program;
+
+    BOOST_CHECK(IsExpectedWitnessProgram(true, wit, 0, program));
+    BOOST_CHECK(IsExpectedWitnessProgram(false, wit, 0, program));
+
+    const valtype name(10, 'a');
+    const valtype value(20, 'b');
+    const CScript nameWit = CNameScript::buildNameUpdate(wit, name, value);
+
+    BOOST_CHECK(IsExpectedWitnessProgram(true, nameWit, 0, program));
+    BOOST_CHECK(!IsExpectedWitnessProgram(false, nameWit, 0, program));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_NamePrefixNotMisinterpreted)
+{
+    /* Name prefixes themselves start with OP_1 to OP_3, which is also
+       a valid start for a witness program.  Make sure that they are not
+       misinterpreted as witness programs.  */
+
+    const valtype name(10, 'a');
+    const valtype value(20, 'b');
+    const valtype rand(15, 'x');
+
+    const CScript nameNew = CNameScript::buildNameNew(CScript(), name, rand);
+    const CScript nameFirst = CNameScript::buildNameFirstupdate(CScript(), name, value, rand);
+    const CScript nameUpdate = CNameScript::buildNameUpdate(CScript(), name, value);
+
+    for (const auto& scr : {nameNew, nameFirst, nameUpdate})
+    {
+        BOOST_CHECK(IsNoWitnessProgram(true, scr));
+        BOOST_CHECK(IsNoWitnessProgram(false, scr));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_segwit_tests.cpp
+++ b/src/test/script_segwit_tests.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2012-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/script.h>
+#include <test/test_bitcoin.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(script_segwit_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Valid)
+{
+    uint256 dummy;
+    CScript p2wsh;
+    p2wsh << OP_0 << ToByteVector(dummy);
+    BOOST_CHECK(p2wsh.IsPayToWitnessScriptHash());
+
+    std::vector<unsigned char> bytes = {OP_0, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_NotOp0)
+{
+    uint256 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_1 << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Size)
+{
+    uint160 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_0 << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Nop)
+{
+    uint256 dummy;
+    CScript notp2wsh;
+    notp2wsh << OP_0 << OP_NOP << ToByteVector(dummy);
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_EmptyScript)
+{
+    CScript notp2wsh;
+    BOOST_CHECK(!notp2wsh.IsPayToWitnessScriptHash ());
+}
+
+BOOST_AUTO_TEST_CASE(IsPayToWitnessScriptHash_Invalid_Pushdata)
+{
+    // A script is not P2WSH if OP_PUSHDATA is used to push the hash.
+    std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+
+    bytes = {OP_0, OP_PUSHDATA2, 32, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+
+    bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(!CScript(bytes.begin(), bytes.end()).IsPayToWitnessScriptHash());
+}
+
+namespace {
+
+bool IsExpectedWitnessProgram(const CScript& script, const int expectedVersion, const std::vector<unsigned char>& expectedProgram)
+{
+    int actualVersion;
+    std::vector<unsigned char> actualProgram;
+    if (!script.IsWitnessProgram(actualVersion, actualProgram)) {
+        return false;
+    }
+    BOOST_CHECK_EQUAL(actualVersion, expectedVersion);
+    BOOST_CHECK(actualProgram == expectedProgram);
+    return true;
+}
+
+bool IsNoWitnessProgram(const CScript& script)
+{
+    int dummyVersion;
+    std::vector<unsigned char> dummyProgram;
+    return !script.IsWitnessProgram(dummyVersion, dummyProgram);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Valid)
+{
+    std::vector<unsigned char> program = {42, 18};
+    CScript wit;
+    wit << OP_0 << program;
+    BOOST_CHECK(IsExpectedWitnessProgram(wit, 0, program));
+
+    wit.clear();
+    program.resize(40);
+    wit << OP_16 << program;
+    BOOST_CHECK(IsExpectedWitnessProgram(wit, 16, program));
+
+    program.resize(32);
+    std::vector<unsigned char> bytes = {OP_5, static_cast<unsigned char>(program.size())};
+    bytes.insert(bytes.end(), program.begin(), program.end());
+    BOOST_CHECK(IsExpectedWitnessProgram(CScript(bytes.begin(), bytes.end()), 5, program));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Version)
+{
+    std::vector<unsigned char> program(10);
+    CScript nowit;
+    nowit << OP_1NEGATE << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Size)
+{
+    std::vector<unsigned char> program(1);
+    CScript nowit;
+    nowit << OP_0 << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+
+    nowit.clear();
+    program.resize(41);
+    nowit << OP_0 << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Nop)
+{
+    std::vector<unsigned char> program(10);
+    CScript nowit;
+    nowit << OP_0 << OP_NOP << program;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_EmptyScript)
+{
+    CScript nowit;
+    BOOST_CHECK(IsNoWitnessProgram(nowit));
+}
+
+BOOST_AUTO_TEST_CASE(IsWitnessProgram_Invalid_Pushdata)
+{
+    // A script is no witness program if OP_PUSHDATA is used to push the hash.
+    std::vector<unsigned char> bytes = {OP_0, OP_PUSHDATA1, 32};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+
+    bytes = {OP_0, OP_PUSHDATA2, 32, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+
+    bytes = {OP_0, OP_PUSHDATA4, 32, 0, 0, 0};
+    bytes.insert(bytes.end(), 32, 0);
+    BOOST_CHECK(IsNoWitnessProgram(CScript(bytes.begin(), bytes.end())));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2608,7 +2608,7 @@ OutputType CWallet::TransactionChangeType(OutputType change_type, const std::vec
         // Check if any destination contains a witness program:
         int witnessversion = 0;
         std::vector<unsigned char> witnessprogram;
-        if (recipient.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
+        if (recipient.scriptPubKey.IsWitnessProgram(true, witnessversion, witnessprogram)) {
             return OutputType::BECH32;
         }
     }

--- a/test/functional/name_segwit.py
+++ b/test/functional/name_segwit.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for names at segwit addresses.
+
+from test_framework.names import NameTestFramework
+
+from test_framework.blocktools import (
+  add_witness_commitment,
+  create_block,
+  create_coinbase,
+)
+from test_framework.messages import (
+  CScriptWitness,
+  CTransaction,
+  CTxInWitness,
+  CTxWitness,
+)
+from test_framework.util import (
+  assert_equal,
+  assert_greater_than,
+  assert_raises_rpc_error,
+  bytes_to_hex_str,
+  hex_str_to_bytes,
+)
+
+from decimal import Decimal
+import io
+
+SEGWIT_ACTIVATION_HEIGHT = 432
+
+
+class NameSegwitTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([["-debug", "-par=1"]] * 1)
+
+  def checkNameValueAddr (self, name, value, addr):
+    """
+    Verifies that the given name has the given value and address.
+    """
+
+    data = self.checkName (0, name, value, None, False)
+    assert_equal (data['address'], addr)
+
+  def findUnspent (self, amount):
+    """
+    Finds and returns an unspent input the node has with at least the
+    given value.
+    """
+
+    unspents = self.node.listunspent ()
+    for u in unspents:
+      if u['amount'] >= amount:
+        return u
+
+    raise AssertionError ("Could not find suitable unspent output")
+
+  def buildDummySegwitNameUpdate (self, name, value, addr):
+    """
+    Builds a transaction that updates the given name to the given value and
+    address.  We assume that the name is at a native segwit script.  The witness
+    of the transaction will be set to two dummy stack elements so that the
+    program itself is "well-formed" even if it won't execute successfully.
+    """
+
+    data = self.node.name_show (name)
+    u = self.findUnspent (Decimal ('0.01'))
+    ins = [data, u]
+    outs = {addr: Decimal ('0.01')}
+
+    txHex = self.node.createrawtransaction (ins, outs)
+    nameOp = {"op": "name_update", "name": name, "value": value}
+    txHex = self.node.namerawtransaction (txHex, 0, nameOp)['hex']
+    txHex = self.node.signrawtransactionwithwallet (txHex)['hex']
+
+    tx = CTransaction ()
+    tx.deserialize (io.BytesIO (hex_str_to_bytes (txHex)))
+    tx.wit = CTxWitness ()
+    tx.wit.vtxinwit.append (CTxInWitness ())
+    tx.wit.vtxinwit[0].scriptWitness = CScriptWitness ()
+    tx.wit.vtxinwit[0].scriptWitness.stack = [b"dummy"] * 2
+    txHex = bytes_to_hex_str (tx.serialize ())
+
+    return txHex
+
+  def tryUpdateSegwitName (self, name, value, addr):
+    """
+    Tries to update the given name to the given value and address.
+    """
+
+    txHex = self.buildDummySegwitNameUpdate (name, value, addr)
+    self.node.sendrawtransaction (txHex, True)
+
+  def tryUpdateInBlock (self, name, value, addr, withWitness):
+    """
+    Tries to update the given name with a dummy witness directly in a block
+    (to bypass any checks done on the mempool).
+    """
+
+    txHex = self.buildDummySegwitNameUpdate (name, value, addr)
+    tx = CTransaction ()
+    tx.deserialize (io.BytesIO (hex_str_to_bytes (txHex)))
+
+    tip = self.node.getbestblockhash ()
+    height = self.node.getblockcount () + 1
+    nTime = self.node.getblockheader (tip)["mediantime"] + 1
+    block = create_block (int (tip, 16), create_coinbase (height), nTime)
+
+    block.vtx.append (tx)
+    add_witness_commitment (block, 0)
+    block.solve ()
+
+    blkHex = bytes_to_hex_str (block.serialize (withWitness))
+    return self.node.submitblock (blkHex)
+
+  def run_test (self):
+    self.node = self.nodes[0]
+
+    # Register a test name to a bech32 pure-segwit address.
+    addr = self.node.getnewaddress ("test", "bech32")
+    name = "d/test"
+    value = "{}"
+    new = self.node.name_new (name)
+    self.node.generate (10)
+    self.firstupdateName (0, name, new, value, {"destAddress": addr})
+    self.node.generate (5)
+    self.checkNameValueAddr (name, value, addr)
+
+    # Before segwit activation, the script should behave as anyone-can-spend.
+    # It will still fail due to non-mandatory flag checks when submitted
+    # into the mempool.
+    assert_greater_than (SEGWIT_ACTIVATION_HEIGHT, self.node.getblockcount ())
+    assert_raises_rpc_error (-26, 'Script failed an OP_EQUALVERIFY operation',
+                             self.tryUpdateSegwitName,
+                             name, "wrong value", addr)
+    self.node.generate (1)
+    self.checkNameValueAddr (name, value, addr)
+
+    # But directly in a block, the update should work with a dummy witness.
+    assert_equal (self.tryUpdateInBlock (name, "stolen", addr,
+                                         withWitness=False),
+                  None)
+    self.checkNameValueAddr (name, "stolen", addr)
+
+    # Activate segwit.  Since this makes the original name expire, we have
+    # to re-register it.
+    self.node.generate (400)
+    new = self.node.name_new (name)
+    self.node.generate (10)
+    self.firstupdateName (0, name, new, value, {"destAddress": addr})
+    self.node.generate (5)
+    self.checkNameValueAddr (name, value, addr)
+
+    # Verify that now trying to update the name without a proper signature
+    # fails differently.
+    assert_greater_than (self.node.getblockcount (), SEGWIT_ACTIVATION_HEIGHT)
+    assert_equal (self.tryUpdateInBlock (name, "wrong value", addr,
+                                         withWitness=True),
+                  'non-mandatory-script-verify-flag'
+                    + ' (Script failed an OP_EQUALVERIFY operation)')
+    self.checkNameValueAddr (name, value, addr)
+
+    # Updating the name ordinarily (with signature) should work fine even
+    # though it is at a segwit address.  Also spending from P2SH-segwit
+    # should work fine.
+    addrP2SH = self.node.getnewaddress ("test", "p2sh-segwit")
+    self.node.name_update (name, "value 2", {"destAddress": addrP2SH})
+    self.node.generate (1)
+    self.checkNameValueAddr (name, "value 2", addrP2SH)
+    self.node.name_update (name, "value 3", {"destAddress": addr})
+    self.node.generate (1)
+    self.checkNameValueAddr (name, "value 3", addr)
+
+
+if __name__ == '__main__':
+  NameSegwitTest ().main ()

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -36,6 +36,9 @@ echo "\nName reorgs..."
 echo "\nName scanning..."
 ./name_scanning.py
 
+echo "\nNames and segwit..."
+./name_segwit.py
+
 echo "\nName operation with sendCoins..."
 ./name_sendcoins.py
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'name_registration.py',
     'name_reorg.py',
     'name_scanning.py',
+    'name_segwit.py',
     'name_sendcoins.py',
     'name_utxo.py',
     'name_wallet.py',


### PR DESCRIPTION
This fixes an issue with names and native segwit scripts (bech32 addresses).  `CScript::IsWitnessProgram` did not strip name prefixes, which meant that names at bech32 addresses were anyone-can-spend even after segwit activation - but the transaction had to be included in a block, since the transaction would be rejected by a non-mandatory rule from the mempool.  P2SH-Segwit is already working as expected.

With this fix, names should work well together with segwit in all variants.  This also includes tests to verify that, including (but not limited to) the situations described in #258.

Note that this is in theory a consensus change, but it is safe to commit because segwit is not yet active for Namecoin.

This includes a cherry-pick from https://github.com/bitcoin/bitcoin/pull/14752, to create a place for the new name/segwit unit tests.