### PR TITLE
Options argument for remaining name RPCs

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -151,6 +151,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "name_history", 1, "options" },
     { "name_scan", 1, "count" },
     { "name_scan", 2, "options" },
+    { "name_pending", 1, "options" },
     { "name_list", 1, "options" },
     { "name_new", 1, "options" },
     { "name_firstupdate", 4, "options" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -147,6 +147,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
+    { "name_show", 1, "options" },
+    { "name_history", 1, "options" },
     { "name_scan", 1, "count" },
     { "name_scan", 2, "options" },
     { "name_new", 1, "options" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -151,6 +151,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "name_history", 1, "options" },
     { "name_scan", 1, "count" },
     { "name_scan", 2, "options" },
+    { "name_list", 1, "options" },
     { "name_new", 1, "options" },
     { "name_firstupdate", 4, "options" },
     { "name_firstupdate", 5, "allow_active" },

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -214,8 +214,6 @@ SendNameOutput (interfaces::Chain::Lock& locked_chain,
   return tx;
 }
 
-const UniValue NO_OPTIONS(UniValue::VOBJ);
-
 } // anonymous namespace
 /* ************************************************************************** */
 
@@ -228,12 +226,17 @@ name_list (const JSONRPCRequest& request)
   if (!EnsureWalletIsAvailable (pwallet, request.fHelp))
     return NullUniValue;
 
-  if (request.fHelp || request.params.size () > 1)
+  if (request.fHelp || request.params.size () > 2)
     throw std::runtime_error (
-        "name_list (\"name\")\n"
+        "name_list (\"name\" (\"options\"))\n"
         "\nShow status of names in the wallet.\n"
         "\nArguments:\n"
         "1. \"name\"          (string, optional) only include this name\n"
+        "2. \"options\"       (object, optional)\n"
+        + NameOptionsHelp ()
+            .withNameEncoding ()
+            .withValueEncoding ()
+            .finish ("") +
         "\nResult:\n"
         "[\n"
         + NameInfoHelp ("  ")
@@ -247,11 +250,15 @@ name_list (const JSONRPCRequest& request)
         + HelpExampleRpc ("name_list", "")
       );
 
-  RPCTypeCheck (request.params, {UniValue::VSTR});
+  RPCTypeCheck (request.params, {UniValue::VSTR, UniValue::VOBJ}, true);
+
+  UniValue options(UniValue::VOBJ);
+  if (request.params.size () >= 2)
+    options = request.params[1].get_obj ();
 
   valtype nameFilter;
-  if (request.params.size () >= 1)
-    nameFilter = DecodeNameFromRPCOrThrow (request.params[0], NO_OPTIONS);
+  if (request.params.size () >= 1 && !request.params[0].isNull ())
+    nameFilter = DecodeNameFromRPCOrThrow (request.params[0], options);
 
   std::map<valtype, int> mapHeights;
   std::map<valtype, UniValue> mapObjects;
@@ -306,8 +313,7 @@ name_list (const JSONRPCRequest& request)
         continue;
 
       UniValue obj
-        = getNameInfo (NO_OPTIONS,
-                       name, nameOp.getOpValue (),
+        = getNameInfo (options, name, nameOp.getOpValue (),
                        COutPoint (tx.GetHash (), nOut),
                        nameOp.getAddress ());
       addOwnershipInfo (nameOp.getAddress (), pwallet, obj);
@@ -737,6 +743,13 @@ sendtoname (const JSONRPCRequest& request)
 
   auto locked_chain = pwallet->chain().lock();
   LOCK(pwallet->cs_wallet);
+
+  /* sendtoname does not support an options argument (e.g. to override the
+     configured name/value encodings).  That would just add to the already
+     long list of rarely used arguments.  Also, this function is inofficially
+     deprecated anyway, see
+     https://github.com/namecoin/namecoin-core/issues/12.  */
+  const UniValue NO_OPTIONS(UniValue::VOBJ);
 
   const valtype name = DecodeNameFromRPCOrThrow (request.params[0], NO_OPTIONS);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4315,7 +4315,7 @@ static const CRPCCommand commands[] =
     { "mining",             "getauxblock",                      &getauxblock,                   {"hash","auxpow"} },
 
     // Name-related wallet calls.
-    { "names",              "name_list",                        &name_list,                     {"name"} },
+    { "names",              "name_list",                        &name_list,                     {"name","options"} },
     { "names",              "name_new",                         &name_new,                      {"name","options"} },
     { "names",              "name_firstupdate",                 &name_firstupdate,              {"name","rand","tx","value","options","allow_active"} },
     { "names",              "name_update",                      &name_update,                   {"name","value","options"} },

--- a/test/functional/name_encodings.py
+++ b/test/functional/name_encodings.py
@@ -497,6 +497,23 @@ class NameEncodingsTest (NameTestFramework):
       assert_equal (len (res), 1)
       return res[0]
     verifyReadMethod (nameScanWrapper)
+    def nameListWrapper (name, *opt):
+      res = self.node.name_list (name, *opt)
+      assert_equal (len (res), 1)
+      return res[0]
+    verifyReadMethod (nameListWrapper)
+
+    # Test that name_list also supports the options argument if no name
+    # is given.
+    res = self.node.name_list (options={"nameEncoding": "utf8"})
+    found = False
+    for entry in res:
+      if 'name' not in entry:
+        continue
+      if entry['name'] == nameUtf8 and entry['name_encoding'] == 'utf8':
+        found = True
+        break
+    assert found
 
   def test_rpcOption (self):
     """

--- a/test/functional/name_encodings.py
+++ b/test/functional/name_encodings.py
@@ -503,17 +503,34 @@ class NameEncodingsTest (NameTestFramework):
       return res[0]
     verifyReadMethod (nameListWrapper)
 
+    # Helper function for testing name_list and name_pending without a name.
+    # It verifies that an array returned from such a function contains the
+    # given name with the given encoding.
+    def resultContainsName (res, name, enc):
+      for entry in res:
+        if 'name' not in entry:
+          continue
+        if entry['name'] == name and entry['name_encoding'] == enc:
+          return True
+      return False
+
     # Test that name_list also supports the options argument if no name
     # is given.
     res = self.node.name_list (options={"nameEncoding": "utf8"})
-    found = False
-    for entry in res:
-      if 'name' not in entry:
-        continue
-      if entry['name'] == nameUtf8 and entry['name_encoding'] == 'utf8':
-        found = True
-        break
-    assert found
+    assert resultContainsName (res, nameUtf8, 'utf8')
+
+    # Create a pending update for name_pending.
+    self.node.name_update (nameAscii, valueUtf8, {"valueEncoding": "utf8"})
+    self.node.name_update (nameUtf8, valueAscii, {"nameEncoding": "utf8"})
+    def namePendingWrapper (name, *opt):
+      res = self.node.name_pending (name, *opt)
+      assert_equal (len (res), 1)
+      return res[0]
+    verifyReadMethod (namePendingWrapper)
+
+    # Also test name_pending with options but without name.
+    res = self.node.name_pending (options={"nameEncoding": "utf8"})
+    assert resultContainsName (res, nameUtf8, 'utf8')
 
   def test_rpcOption (self):
     """


### PR DESCRIPTION
This adds an optional `options` argument for the remaining name RPCs: `name_show`, `name_history`, `name_list` and `name_pending`, as suggested in #194.  For now, the only implemented options are `nameEncoding` and `valueEncoding`, allowing to override the default-configured encodings on a per-RPC basis (implementing another missing part of #246).

Two name-related RPC methods are remaining without an `options` argument, where I suggest to not add it at all:

- `namerawtransaction`:  This already has many arguments and adding an `options` argument seems not too useful.  `namecoin-tx` can already be used instead, which allows to have arbitrary names and values in hex-encoding.
- `sendtoname`:  This also already has many arguments so adding `options` would make the signature even more complex.  Furthermore, this call is "informally deprecated" anyway, see #12, and probably not often used.