### PR TITLE
Remove "ismine" for RPC calls without wallet.

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -15,6 +15,9 @@
 - `name_filter` has been removed.  Instead, `name_scan` with the newly added
   filtering options can be used.
 
+- `ismine` is no longer added to RPC results if no wallet is associated
+  to an RPC call.
+
 ## Version 0.17
 
 - Previously, `createrawtransaction` supported a separate argument for creating

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 Daniel Kraft
+// Copyright (c) 2014-2019 Daniel Kraft
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -133,10 +133,7 @@ addOwnershipInfo (const CScript& addr, const CWallet* pwallet,
                   UniValue& data)
 {
   if (pwallet == nullptr)
-    {
-      data.pushKV ("ismine", false);
-      return;
-    }
+    return;
 
   AssertLockHeld (pwallet->cs_wallet);
   const isminetype mine = IsMine (*pwallet, addr);

--- a/test/functional/name_ismine.py
+++ b/test/functional/name_ismine.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 Daniel Kraft
+# Copyright (c) 2018-2019 Daniel Kraft
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -73,6 +73,16 @@ class NameIsMineTest (NameTestFramework):
     # name_scan, name_list
     self.verifyExpectedIsMineInList (self.node.name_scan ())
     self.verifyExpectedIsMineInList (self.node.name_list ())
+
+    # Test the multiwallet situation.  If no wallet is specified for the RPC,
+    # then ismine should not be set at all.
+    self.node.createwallet ("extra")
+    defaultRpc = self.node.get_wallet_rpc ("")
+    extraRpc = self.node.get_wallet_rpc ("extra")
+    self.verifyExpectedIsMineInList (defaultRpc.name_list ())
+    for nm in ["d/a", "d/b"]:
+      assert 'ismine' not in self.node.name_show (nm)
+      assert_equal (extraRpc.name_show (nm)['ismine'], False)
 
 if __name__ == '__main__':
   NameIsMineTest ().main ()


### PR DESCRIPTION
When no wallet is associated to an RPC call like `name_show`, do not include `ismine` in the result at all.  Previously, `ismine=false` was returned in those cases.  But this is misleading, as it implies that the name is certainly *not* in the wallet.

Instead, we now do not include `ismine` as wallet-specific field at all. This means that especially multi-wallet situations without a specified wallet now behave in the same way as if the wallet were not compiled in at all.  This makes the behaviour consistent.

Note that standard situations where the user has exactly one wallet are not affected at all by this change.  Only multi-wallet users are.