### PR TITLE
Add auxpow to getblock help text

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -897,6 +897,14 @@ static UniValue getblock(const JSONRPCRequest& request)
             "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
+            "  \"auxpow\" : {           (object) The auxpow object attached to this block\n"
+            "    \"tx\" : {...},        (object) The parent chain coinbase tx of this auxpow\n"
+            "    \"index\" : 0,         (numeric) Merkle index of the parent coinbase\n"
+            "    \"merklebranch\" : [...], (array) Merke branch of the parent coinbase\n"
+            "    \"chainindex\" : n,    (numeric) Index in the auxpow Merkle tree\n"
+            "    \"chainmerklebranch\" : [...], (array) Branch in the auxpow Merkle tree\n"
+            "    \"parentblock\" : \"xx\" (string) The parent block serialised as hex string\n"
+            "  }\n"
             "}\n"
                     },
                     RPCResult{"for verbosity = 2",


### PR DESCRIPTION
The `getblock` help text was missing a description of the `auxpow` field in the returned JSON object.  This adds the missing help text.

Note that the field itself was already present and is not changed.  This is purely about the documentation in the online help.

Fixes https://github.com/namecoin/namecoin-core/issues/289.