### PR TITLE
Fix PYTHONPATH in convertBechAddress.sh

### DIFF
--- a/contrib/namecoin/convertBechAddress.sh
+++ b/contrib/namecoin/convertBechAddress.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
-PYTHONPATH="test/functional/test_framework"
+export PYTHONPATH="test/functional/test_framework"
 contrib/namecoin/convertBechAddress.py $@


### PR DESCRIPTION
`convertBechAddress.sh` wasn't exporting the `PYTHONPATH` variable, so Python couldn't see the variable, which caused `ImportError: No module named 'segwit_addr'` if the bech32 library wasn't already in the system Python path.