### PR TITLE
Set auxpow "hashBlock" to zero

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -16,7 +16,6 @@
 #include <util/system.h>
 
 #include <algorithm>
-#include <cassert>
 
 namespace
 {

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -41,9 +41,6 @@ bool
 CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
                 const Consensus::Params& params) const
 {
-    if (coinbaseTx.nIndex != 0)
-        return error("AuxPow is not a generate");
-
     if (params.fStrictChainId && parentBlock.GetChainId () == nChainId)
         return error("Aux POW parent has our chain ID");
 
@@ -57,12 +54,11 @@ CAuxPow::check (const uint256& hashAuxBlock, int nChainId,
     std::reverse (vchRootHash.begin (), vchRootHash.end ()); // correct endian
 
     // Check that we are in the parent block merkle tree
-    if (CheckMerkleBranch(coinbaseTx.GetHash(), coinbaseTx.vMerkleBranch,
-                          coinbaseTx.nIndex)
+    if (CheckMerkleBranch(coinbaseTx->GetHash(), vMerkleBranch, 0)
           != parentBlock.hashMerkleRoot)
         return error("Aux POW merkle root incorrect");
 
-    const CScript script = coinbaseTx.tx->vin[0].scriptSig;
+    const CScript script = coinbaseTx->vin[0].scriptSig;
 
     // Check that the same work is not submitted twice to our chain.
     //
@@ -191,11 +187,10 @@ CAuxPow::createAuxPow (const CPureBlockHeader& header)
   parent.hashMerkleRoot = BlockMerkleRoot (parent);
 
   /* Construct the auxpow object.  */
-  std::unique_ptr<CAuxPow> auxpow(new CAuxPow (coinbaseRef));
+  std::unique_ptr<CAuxPow> auxpow(new CAuxPow (std::move (coinbaseRef)));
+  assert (auxpow->vMerkleBranch.empty ());
   assert (auxpow->vChainMerkleBranch.empty ());
   auxpow->nChainIndex = 0;
-  assert (auxpow->coinbaseTx.vMerkleBranch.empty ());
-  auxpow->coinbaseTx.nIndex = 0;
   auxpow->parentBlock = parent;
 
   return auxpow;

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -32,62 +32,6 @@ class CAuxPowForTest;
 static const unsigned char pchMergedMiningHeader[] = { 0xfa, 0xbe, 'm', 'm' };
 
 /**
- * Base class for CMerkleTx that just holds the fields and implements
- * serialisation.  This is the part that is needed for CAuxPow.  The other
- * functionality, needed by the wallet, is kept in CMerkleTx itself (defined
- * in wallet/wallet.h as in upstream Bitcoin).
- */
-class CBaseMerkleTx
-{
-public:
-    CTransactionRef tx;
-    uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
-
-    /* An nIndex == -1 means that hashBlock (in nonzero) refers to the earliest
-     * block in the chain we know this or any in-wallet dependency conflicts
-     * with. Older clients interpret nIndex == -1 as unconfirmed for backward
-     * compatibility.
-     */
-    int nIndex;
-
-    CBaseMerkleTx()
-    {
-        SetTx(MakeTransactionRef());
-        Init();
-    }
-
-    explicit CBaseMerkleTx(CTransactionRef arg)
-    {
-        SetTx(std::move(arg));
-        Init();
-    }
-
-    void Init()
-    {
-        hashBlock = uint256();
-        nIndex = -1;
-    }
-
-    void SetTx(CTransactionRef arg)
-    {
-        tx = std::move(arg);
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(tx);
-        READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
-        READWRITE(nIndex);
-    }
-
-    const uint256& GetHash() const { return tx->GetHash(); }
-};
-
-/**
  * Data for the merge-mining auxpow.  This uses a merkle tx (the parent block's
  * coinbase tx) and a second merkle branch to link the actual Namecoin block
  * header to the parent block header, which is mined to satisfy the PoW.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -96,17 +96,16 @@ UniValue AuxpowToJSON(const CAuxPow& auxpow)
 
     {
         UniValue tx(UniValue::VOBJ);
-        tx.pushKV("hex", EncodeHexTx(*auxpow.coinbaseTx.tx));
-        TxToJSON(*auxpow.coinbaseTx.tx, auxpow.parentBlock.GetHash(), tx);
+        tx.pushKV("hex", EncodeHexTx(*auxpow.coinbaseTx));
+        TxToJSON(*auxpow.coinbaseTx, auxpow.parentBlock.GetHash(), tx);
         result.pushKV("tx", tx);
     }
 
-    result.pushKV("index", auxpow.coinbaseTx.nIndex);
     result.pushKV("chainindex", auxpow.nChainIndex);
 
     {
         UniValue branch(UniValue::VARR);
-        for (const auto& node : auxpow.coinbaseTx.vMerkleBranch)
+        for (const auto& node : auxpow.vMerkleBranch)
             branch.push_back(node.GetHex());
         result.pushKV("merklebranch", branch);
     }

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -52,10 +52,11 @@ class CAuxPowForTest : public CAuxPow
 public:
 
   explicit inline CAuxPowForTest (CTransactionRef txIn)
-    : CAuxPow (txIn)
+    : CAuxPow (std::move (txIn))
   {}
 
   using CAuxPow::coinbaseTx;
+  using CAuxPow::vMerkleBranch;
   using CAuxPow::vChainMerkleBranch;
   using CAuxPow::nChainIndex;
   using CAuxPow::parentBlock;
@@ -195,9 +196,7 @@ CAuxpowBuilder::get (const CTransactionRef tx) const
   LOCK(cs_main);
 
   CAuxPowForTest res(tx);
-  res.coinbaseTx.nIndex = 0;
-  res.coinbaseTx.vMerkleBranch
-      = merkle_tests::BlockMerkleBranch (parentBlock, res.coinbaseTx.nIndex);
+  res.vMerkleBranch = merkle_tests::BlockMerkleBranch (parentBlock, 0);
 
   res.vChainMerkleBranch = auxpowChainMerkleBranch;
   res.nChainIndex = auxpowChainIndex;

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -195,7 +195,6 @@ CAuxpowBuilder::get (const CTransactionRef tx) const
   LOCK(cs_main);
 
   CAuxPowForTest res(tx);
-  res.coinbaseTx.hashBlock = parentBlock.GetHash ();
   res.coinbaseTx.nIndex = 0;
   res.coinbaseTx.vMerkleBranch
       = merkle_tests::BlockMerkleBranch (parentBlock, res.coinbaseTx.nIndex);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,7 +7,6 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <amount.h>
-#include <auxpow.h> // contains CBaseMerkleTx
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <outputtype.h>
@@ -251,19 +250,56 @@ struct COutputEntry
 };
 
 /** A transaction with a merkle branch linking it to the block chain. */
-class CMerkleTx : public CBaseMerkleTx
+class CMerkleTx
 {
 private:
   /** Constant used in hashBlock to indicate tx has been abandoned */
     static const uint256 ABANDON_HASH;
 
 public:
+    CTransactionRef tx;
+    uint256 hashBlock;
 
-    CMerkleTx() = default;
+    /* An nIndex == -1 means that hashBlock (in nonzero) refers to the earliest
+     * block in the chain we know this or any in-wallet dependency conflicts
+     * with. Older clients interpret nIndex == -1 as unconfirmed for backward
+     * compatibility.
+     */
+    int nIndex;
+
+    CMerkleTx()
+    {
+        SetTx(MakeTransactionRef());
+        Init();
+    }
 
     explicit CMerkleTx(CTransactionRef arg)
-      : CBaseMerkleTx(arg)
-    {}
+    {
+        SetTx(std::move(arg));
+        Init();
+    }
+
+    void Init()
+    {
+        hashBlock = uint256();
+        nIndex = -1;
+    }
+
+    void SetTx(CTransactionRef arg)
+    {
+        tx = std::move(arg);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        std::vector<uint256> vMerkleBranch; // For compatibility with older versions.
+        READWRITE(tx);
+        READWRITE(hashBlock);
+        READWRITE(vMerkleBranch);
+        READWRITE(nIndex);
+    }
 
     void SetMerkleBranch(const uint256& block_hash, int posInBlock);
 
@@ -286,6 +322,7 @@ public:
     bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
     void setAbandoned() { hashBlock = ABANDON_HASH; }
 
+    const uint256& GetHash() const { return tx->GetHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
     bool IsImmatureCoinBase(interfaces::Chain::Lock& locked_chain) const;
 };

--- a/test/functional/auxpow_mining.py
+++ b/test/functional/auxpow_mining.py
@@ -109,7 +109,6 @@ class AuxpowMiningTest (BitcoinTestFramework):
     data = self.nodes[1].getblock (auxblock['hash'])
     assert 'auxpow' in data
     auxJson = data['auxpow']
-    assert_equal (auxJson['index'], 0)
     assert_equal (auxJson['chainindex'], 0)
     assert_equal (auxJson['merklebranch'], [])
     assert_equal (auxJson['chainmerklebranch'], [])

--- a/test/functional/auxpow_zerohash.py
+++ b/test/functional/auxpow_zerohash.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Daniel Kraft
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests that the "hashBlock" field of the Merkle coinbase tx in an auxpow
+# is zero'ed when the block is processed/retrieved from a node, and that
+# auxpows with a zero hashBlock are actually accepted just fine.  (This has
+# always been the case, but the test just makes sure this is explicitly
+# tested for the future as well.)
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import (
+  create_block,
+  create_coinbase,
+)
+from test_framework.messages import (
+  CAuxPow,
+  CBlock,
+  CInv,
+  msg_getdata,
+  uint256_from_compact,
+)
+from test_framework.mininode import (
+  P2PDataStore,
+  P2PInterface,
+)
+from test_framework.util import (
+  assert_equal,
+  hex_str_to_bytes,
+  wait_until,
+)
+
+from test_framework.auxpow_testing import computeAuxpow
+
+import codecs
+from io import BytesIO
+
+
+class P2PBlockGetter (P2PInterface):
+  """
+  P2P connection class that allows requesting blocks from a node's P2P
+  connection to verify how they are sent.
+  """
+
+  def on_block (self, msg):
+    self.block = msg.block
+
+  def getBlock (self, blkHash):
+    self.block = None
+    inv = CInv (t=2, h=int (blkHash, 16))
+    self.send_message (msg_getdata (inv=[inv]))
+    wait_until (lambda: self.block is not None)
+    return self.block
+
+
+class AuxpowZeroHashTest (BitcoinTestFramework):
+
+  def set_test_params (self):
+    self.num_nodes = 1
+    self.setup_clean_chain = True
+    self.extra_args = [["-whitelist=127.0.0.1"]]
+
+  def run_test (self):
+    node = self.nodes[0]
+    p2pStore = node.add_p2p_connection (P2PDataStore ())
+    p2pGetter = node.add_p2p_connection (P2PBlockGetter ())
+
+    self.log.info ("Adding a block with non-zero hash in the auxpow...")
+    blk, blkHash = self.createBlock ()
+    blk.auxpow.hashBlock = 12345678
+    blkHex = blk.serialize ().hex ()
+    assert_equal (node.submitblock (blkHex), None)
+    assert_equal (node.getbestblockhash (), blkHash)
+
+    self.log.info ("Retrieving block through RPC...")
+    gotHex = node.getblock (blkHash, 0)
+    assert gotHex != blkHex
+    gotBlk = CBlock ()
+    gotBlk.deserialize (BytesIO (hex_str_to_bytes (gotHex)))
+    assert_equal (gotBlk.auxpow.hashBlock, 0)
+
+    self.log.info ("Retrieving block through P2P...")
+    gotBlk = p2pGetter.getBlock (blkHash)
+    assert_equal (gotBlk.auxpow.hashBlock, 0)
+
+    self.log.info ("Sending zero-hash auxpow through RPC...")
+    blk, blkHash = self.createBlock ()
+    blk.auxpow.hashBlock = 0
+    assert_equal (node.submitblock (blk.serialize ().hex ()), None)
+    assert_equal (node.getbestblockhash (), blkHash)
+
+    self.log.info ("Sending zero-hash auxpow through P2P...")
+    blk, blkHash = self.createBlock ()
+    blk.auxpow.hashBlock = 0
+    p2pStore.send_blocks_and_test ([blk], node, success=True)
+    assert_equal (node.getbestblockhash (), blkHash)
+
+  def createBlock (self):
+    """
+    Creates and mines a new block with auxpow.
+    """
+
+    bestHash = self.nodes[0].getbestblockhash ()
+    bestBlock = self.nodes[0].getblock (bestHash)
+    tip = int (bestHash, 16)
+    height = bestBlock["height"] + 1
+    time = bestBlock["time"] + 1
+
+    block = create_block (tip, create_coinbase (height), time)
+    block.mark_auxpow ()
+    block.rehash ()
+    newHash = "%032x" % block.sha256
+
+    target = b"%032x" % uint256_from_compact (block.nBits)
+    auxpowHex = computeAuxpow (newHash, target, True)
+    block.auxpow = CAuxPow ()
+    block.auxpow.deserialize (BytesIO (hex_str_to_bytes (auxpowHex)))
+
+    return block, newHash
+
+
+if __name__ == '__main__':
+  AuxpowZeroHashTest ().main ()

--- a/test/functional/auxpow_zerohash.py
+++ b/test/functional/auxpow_zerohash.py
@@ -96,6 +96,18 @@ class AuxpowZeroHashTest (BitcoinTestFramework):
     p2pStore.send_blocks_and_test ([blk], node, success=True)
     assert_equal (node.getbestblockhash (), blkHash)
 
+    self.log.info ("Sending non-zero nIndex auxpow through RPC...")
+    blk, blkHash = self.createBlock ()
+    blk.auxpow.nIndex = 42
+    assert_equal (node.submitblock (blk.serialize ().hex ()), None)
+    assert_equal (node.getbestblockhash (), blkHash)
+
+    self.log.info ("Sending non-zero nIndex auxpow through P2P...")
+    blk, blkHash = self.createBlock ()
+    blk.auxpow.nIndex = 42
+    p2pStore.send_blocks_and_test ([blk], node, success=True)
+    assert_equal (node.getbestblockhash (), blkHash)
+
   def createBlock (self):
     """
     Creates and mines a new block with auxpow.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -200,6 +200,7 @@ BASE_SCRIPTS = [
     'auxpow_mining.py',
     'auxpow_mining.py --segwit',
     'auxpow_invalidpow.py',
+    'auxpow_zerohash.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
This change refactors the auxpow code so that the `hashBlock` field of a serialised `CAuxPow` is always set to zero.  Since that field is never actually used or checked in code (also not in the existing network without this change), that is a safe change to make.  It increases compressibility of the data, which can help SPV clients (see #288 for discussion about that).

In addition, this also changes the code to ignore the `nIndex` field when deserialising a `CAuxPow`.  This value is not necessary either, as it has to be always zero (for a coinbase tx as in an auxpow).  This change affects consensus:  Nodes with this patch applied will accept auxpows with a non-zero `nIndex`, while nodes without will reject those auxpows.  But since the auxpow is only there to provide PoW for a block and does not affect the consensus state itself, this change is safe.  All that an attacker could do is make old nodes reject blocks that new nodes accept, *due to invalid PoW*.  Once relayed by a new node, the same blocks will be accepted by the old code as well.  Thus, this "attack" is not different from an attacker simply trying to withhold blocks for certain peers, which they can do already if they want.