### PR TITLE
Test multiple updates of a name in one block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -647,7 +647,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     }
 
     if (!pool.checkNameOps(tx))
-        return false;
+        return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-name-error");
 
     {
         CCoinsView dummy;

--- a/test/functional/name_multiupdate.py
+++ b/test/functional/name_multiupdate.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the behaviour of multiple updates for one name within a single block.
+
+from test_framework.names import NameTestFramework, buildMultiUpdateBlock
+
+from test_framework.util import (
+  assert_equal,
+  assert_raises_rpc_error,
+)
+
+
+class NameMultiUpdateTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_clean_chain = True
+    self.setup_name_test ([["-debug", "-namehistory"]] * 1)
+
+  def run_test (self):
+    self.node = self.nodes[0]
+    self.node.generate (110)
+
+    # Register a test name.
+    name = "d/test"
+    new = self.node.name_new (name)
+    self.node.generate (10)
+    self.firstupdateName (0, name, new, "first")
+    self.node.generate (5)
+    self.checkName (0, name, "first", None, False)
+
+    # Update the name (keep the transaction pending) and check that another
+    # update is not allowed by the mempool.
+    txid = self.node.name_update (name, "second")
+    assert_raises_rpc_error (-25, "already a pending update",
+                             self.node.name_update, name, "wrong")
+    self.node.generate (1)
+    self.checkName (0, name, "second", None, False)
+
+    # Build two update transactions building on each other and try to
+    # submit them both as transactions.
+    blk = buildMultiUpdateBlock (self.node, name, ["third", "wrong"])
+    assert_equal (len (blk.vtx), 3)
+    self.node.sendrawtransaction (blk.vtx[1].serialize ().hex ())
+    assert_raises_rpc_error (-26, "txn-mempool-name-error",
+                             self.node.sendrawtransaction,
+                             blk.vtx[2].serialize ().hex ())
+    self.node.generate (1)
+    self.checkName (0, name, "third", None, False)
+
+    # Submitting two updates at once in a block is fine as long as that does
+    # not go through the mempool.
+    blk = buildMultiUpdateBlock (self.node, name, ["fourth", "fifth"])
+    assert_equal (self.node.submitblock (blk.serialize ().hex ()), None)
+
+    # Verify that the second update took effect, as well as the entire
+    # history of the name.
+    self.checkName (0, name, "fifth", None, False)
+    values = [h["value"] for h in self.node.name_history (name)]
+    assert_equal (values, ["first", "second", "third", "fourth", "fifth"])
+
+
+if __name__ == '__main__':
+  NameMultiUpdateTest ().main ()

--- a/test/functional/run_name_tests.sh
+++ b/test/functional/run_name_tests.sh
@@ -21,6 +21,9 @@ echo "\nName listunspent..."
 echo "\nName multisig..."
 ./name_multisig.py
 
+echo "\nName multiupdates..."
+./name_multiupdate.py
+
 echo "\nName pending..."
 ./name_pending.py
 

--- a/test/functional/test_framework/names.py
+++ b/test/functional/test_framework/names.py
@@ -1,12 +1,95 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2017 Daniel Kraft
+# Copyright (c) 2014-2019 Daniel Kraft
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # General code for Namecoin tests.
 
 from .test_framework import BitcoinTestFramework
-from .util import *
+
+from .blocktools import (
+  add_witness_commitment,
+  create_block,
+  create_coinbase,
+)
+from .messages import CTransaction
+from .util import (
+  assert_equal,
+  gather_inputs,
+  hex_str_to_bytes,
+  sync_blocks,
+  sync_mempools,
+)
+
+from decimal import Decimal
+import io
+
+
+def buildMultiUpdateBlock (node, name, values):
+  """
+  Constructs a CBlock instance that updates the name in a series to all
+  of the given values.  This is something that the mempool policy does not
+  allow, while it is perfectly fine in the consensus if included in a block.
+
+  With this function, other tests can evaluate how this edge case is handled.
+  """
+
+  nameValue = Decimal ("0.01")
+  fee = Decimal ("0.01")
+
+  tip = node.getbestblockhash ()
+  height = node.getblockcount () + 1
+  nTime = node.getblockheader (tip)["mediantime"] + 1
+  block = create_block (int (tip, 16), create_coinbase (height), nTime)
+
+  # While iterating, we keep track of the previous transaction that we build
+  # on.  Initialise with the current data for the name from the blockchain
+  # as well as some random currency inputs to pay fees.
+  prevVal, prevIns = gather_inputs (node, len (values) * fee)
+  prevOuts = None
+  prevNameOut = node.name_show (name)
+
+  for v in values:
+    ins = prevIns
+    ins.append (prevNameOut)
+
+    addrName = node.getnewaddress ()
+    addrChange = node.getnewaddress ()
+    outs = [{addrName: nameValue}, {addrChange: prevVal - fee}]
+
+    txHex = node.createrawtransaction (ins, outs)
+    nameOp = {"op": "name_update", "name": name, "value": v}
+    txHex = node.namerawtransaction (txHex, 0, nameOp)["hex"]
+
+    signed = node.signrawtransactionwithwallet (txHex, prevOuts)
+    assert_equal (signed["complete"], True)
+    txHex = signed["hex"]
+
+    tx = CTransaction ()
+    tx.deserialize (io.BytesIO (hex_str_to_bytes (txHex)))
+    block.vtx.append (tx)
+
+    # Update the variables about the previous transaction for this one,
+    # so that the next is chained on correctly.
+    txid = node.decoderawtransaction (txHex)["txid"]
+    prevNameOut = {"txid": txid, "vout": 0}
+    prevVal -= fee
+    prevIns = [{"txid": txid, "vout": 1}]
+
+    data = node.decoderawtransaction (txHex)
+    prevOuts = []
+    for i in range (len (data["vout"])):
+      prevOuts.append ({
+        "txid": txid,
+        "vout": i,
+        "scriptPubKey": data["vout"][i]["scriptPubKey"]["hex"]
+      })
+
+  add_witness_commitment (block, 0)
+  block.solve ()
+
+  return block
+
 
 class NameTestFramework (BitcoinTestFramework):
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'name_listunspent.py',
     'name_multisig.py',
     'name_multisig.py --bip16-active',
+    'name_multiupdate.py',
     'name_pending.py',
     'name_rawtx.py',
     'name_registration.py',


### PR DESCRIPTION
Namecoin's memory pool implementation does not allow multiple updates to a single name (in a chain), but the consensus logic is fine with that.  In other words, it is possible to update a name multiple times in a single block as long as those updates are in that one block.

This adds a regression test for this situation as well as the mempool handling, to make sure that the current and expected state is preserved and no accidental regression is introduced with this edge case.

Also includes a tiny change to the logic of the mempool acceptance itself, so that a proper error code is returned if accepting a transaction fails due to name rules.