### PR TITLE
 Allow createauxblock RPC with different coinbase addresses

### DIFF
--- a/src/rpc/auxpow_miner.h
+++ b/src/rpc/auxpow_miner.h
@@ -7,6 +7,7 @@
 
 #include <miner.h>
 #include <script/script.h>
+#include <script/standard.h>
 #include <sync.h>
 #include <uint256.h>
 #include <univalue.h>
@@ -40,12 +41,9 @@ private:
   std::vector<std::unique_ptr<CBlockTemplate>> templates;
   /** Maps block hashes to pointers in vTemplates.  Does not own the memory.  */
   std::map<uint256, const CBlock*> blocks;
+  /** Maps coinbase script hashes to pointers in vTemplates.  Does not own the memory.  */
+  std::map<CScriptID, const CBlock*> curBlocks;
 
-  /**
-   * The block we are "currently" working on.  This does not own the memory,
-   * instead, it points into an element of templates.
-   */
-  CBlock* pblockCur = nullptr;
   /** The current extra nonce for block creation.  */
   unsigned extraNonce = 0;
 

--- a/test/functional/auxpow_mining.py
+++ b/test/functional/auxpow_mining.py
@@ -192,5 +192,10 @@ class AuxpowMiningTest (BitcoinTestFramework):
     assert_equal (addr1, coinbaseAddr)
     assert_equal (addr2, coinbaseAddr)
 
+    # Ensure that different payout addresses will generate different auxblocks
+    auxblock1 = self.nodes[0].createauxblock(self.nodes[0].getnewaddress ())
+    auxblock2 = self.nodes[0].createauxblock(self.nodes[0].getnewaddress ())
+    assert auxblock1['hash'] != auxblock2['hash']
+
 if __name__ == '__main__':
   AuxpowMiningTest ().main ()


### PR DESCRIPTION
AuxpowMiner::createAuxBlock() only caches a single block for a specific height. If we call createauxblock RPC multiple times with different coinbase payout addresses in that case, they will actually all use the first address. This commit uses a map with the coinbase transaction script hash as the cache so that we can get the correct results.