### PR TITLE
Schedule segwit activation softfork.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,8 +91,7 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
-        // FIXME: Activate BIP16 with a softfork.
-        consensus.BIP16Height = 10000000;
+        consensus.BIP16Height = 475000;
         /* Note that these are not the actual activation heights, but blocks
            after them.  They are too deep in the chain to be ever reorged,
            and thus this is also fine.  */
@@ -257,8 +256,7 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 210000;
-        // FIXME: Activate BIP16 with a softfork.
-        consensus.BIP16Height = 10000000;
+        consensus.BIP16Height = 232000;
         /* As before, these are not the actual activation heights but some
            blocks after them.  */
         consensus.BIP34Height = 130000;


### PR DESCRIPTION
This schedules a softfork activating BIP16 (P2SH), Segwit and CSV at a future blockheight on mainnet and testnet.

On mainnet, the activation will happen at block **475,000**, which is expected to be mined in about half a year.  On testnet, the activation happens at block 232,000, or in one to two weeks (but depending strongly on the mining activity on testnet).

See #239 for a discussion, including the commitment to update timely by many of the most important
mining pools.