### PR TITLE
Allow multiple updates of a name per block

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -2,6 +2,13 @@
 
 ## Version 0.19
 
+- The mempool now allows multiple updates of a single name (in a chain of
+  transactions).  This is something that is allowed in blocks already,
+  i.e. it is just a policy change.  The `name_update` RPC command still
+  prevents such transactions from being created for now, until miners and
+  relaying nodes have updated sufficiently.  More details can be found in
+  [#322](https://github.com/namecoin/namecoin-core/pull/322).
+
 ## Version 0.18
 
 - BIP16, CSV and Segwit will be activated at block height 475,000 on mainnet

--- a/src/names/main.cpp
+++ b/src/names/main.cpp
@@ -221,10 +221,15 @@ CheckNameTransaction (const CTransaction& tx, unsigned nHeight,
                               REJECT_INVALID, "tx-nameupdate-name-mismatch",
                               "NAME_UPDATE name mismatch to name input");
 
-      /* This is actually redundant, since expired names are removed
-         from the UTXO set and thus not available to be spent anyway.
-         But it does not hurt to enforce this here, too.  It is also
-         exercised by the unit tests.  */
+      /* If the name input is pending, then no further checks with respect
+         to the name input in the name database are done.  Otherwise, we verify
+         that the name input matches the name database; this is redundant
+         as UTXO handling takes care of it anyway, but we do it for
+         an extra safety layer.  */
+      const unsigned inHeight = coinIn.nHeight;
+      if (inHeight == MEMPOOL_HEIGHT)
+        return true;
+
       CNameData oldName;
       if (!view.GetName (name, oldName))
         return state.Invalid (ValidationInvalidReason::CONSENSUS, false,
@@ -234,11 +239,7 @@ CheckNameTransaction (const CTransaction& tx, unsigned nHeight,
         return state.Invalid (ValidationInvalidReason::CONSENSUS, false,
                               REJECT_INVALID, "tx-nameupdate-expired",
                               "NAME_UPDATE on an expired name");
-
-      /* This is an internal consistency check.  If everything is fine,
-         the input coins from the UTXO database should match the
-         name database.  */
-      assert (static_cast<unsigned> (coinIn.nHeight) == oldName.getHeight ());
+      assert (inHeight == oldName.getHeight ());
       assert (tx.vin[nameIn].prevout == oldName.getUpdateOutpoint ());
 
       return true;

--- a/src/names/mempool.cpp
+++ b/src/names/mempool.cpp
@@ -14,28 +14,6 @@
 
 /* ************************************************************************** */
 
-uint256
-CNameMemPool::getTxForName (const valtype& name) const
-{
-  NameTxMap::const_iterator mi;
-
-  mi = mapNameRegs.find (name);
-  if (mi != mapNameRegs.end ())
-    {
-      assert (mapNameUpdates.count (name) == 0);
-      return mi->second;
-    }
-
-  mi = mapNameUpdates.find (name);
-  if (mi != mapNameUpdates.end ())
-    {
-      assert (mapNameRegs.count (name) == 0);
-      return mi->second;
-    }
-
-  return uint256 ();
-}
-
 void
 CNameMemPool::addUnchecked (const CTxMemPoolEntry& entry)
 {

--- a/src/names/mempool.h
+++ b/src/names/mempool.h
@@ -20,8 +20,8 @@ class CTxMemPoolEntry;
 /**
  * Handle the name component of the transaction mempool.  This keeps track
  * of name operations that are in the mempool and ensures that all transactions
- * kept are consistent.  E. g., no two transactions are allowed to register
- * the same name, and name registration transactions are removed if a
+ * kept are consistent.  For instance, no two transactions are allowed to
+ * register the same name, and name registration transactions are removed if a
  * conflicting registration makes it into a block.
  */
 class CNameMemPool
@@ -29,120 +29,120 @@ class CNameMemPool
 
 private:
 
-  /** The parent mempool object.  Used to, e. g., remove conflicting tx.  */
+  /** The parent mempool object.  Used to e.g. remove conflicting tx.  */
   CTxMemPool& pool;
-
-  /** Type used for internal indices.  */
-  typedef std::map<valtype, uint256> NameTxMap;
 
   /**
    * Keep track of names that are registered by transactions in the pool.
-   * Map name to registering transaction.
+   * For any given name, at most one registering transaction is allowed in the
+   * mempool (as all others would conflict with it).
    */
-  NameTxMap mapNameRegs;
+  std::map<valtype, uint256> mapNameRegs;
 
-  /** Map pending name updates to transaction IDs.  */
-  NameTxMap mapNameUpdates;
+  /**
+   * Keep track of all transactions that update a given name.  For each name,
+   * this may be a whole chain of updates.  This field is used to remove the
+   * transactions from the mempool should the name expire (and the updates
+   * thus become invalid).
+   */
+  std::map<valtype, std::set<uint256>> updates;
 
   /**
    * Map NAME_NEW hashes to the corresponding transaction IDs.  This is
    * data that is kept only in memory but never cleared (until a restart).
    * It is used to prevent "name_new stealing", at least in a "soft" way.
    */
-  NameTxMap mapNameNews;
+  std::map<valtype, uint256> mapNameNews;
 
 public:
 
   /**
-   * Construct with reference to parent mempool.
-   * @param p The parent pool.
+   * Constructs with reference to parent mempool.
    */
-  explicit inline CNameMemPool (CTxMemPool& p)
-    : pool(p), mapNameRegs(), mapNameUpdates(), mapNameNews()
+  explicit CNameMemPool (CTxMemPool& p)
+    : pool(p)
   {}
 
   /**
-   * Check whether a particular name is being registered by
+   * Checks whether a particular name is being registered by
    * some transaction in the mempool.  Does not lock, this is
    * done by the parent mempool (which calls through afterwards).
-   * @param name The name to check for.
-   * @return True iff there's a matching name registration in the pool.
    */
-  inline bool
+  bool
   registersName (const valtype& name) const
   {
     return mapNameRegs.count (name) > 0;
   }
 
   /**
-   * Check whether a particular name has a pending update.  Does not lock.
-   * @param name The name to check for.
-   * @return True iff there's a matching name update in the pool.
+   * Checks whether a particular name has at least one pending update.
+   * Does not lock.
    */
-  inline bool
+  bool
   updatesName (const valtype& name) const
   {
-    return mapNameUpdates.count (name) > 0;
+    const auto mit = updates.find (name);
+    if (mit == updates.end ())
+      return false;
+    return !mit->second.empty ();
   }
 
   /**
-   * Clear all data.
+   * Returns the last outpoint of a (potential) chain of pending name operations
+   * for the given name.  This is the output that should be spent with the
+   * next constructed name update.  Returns a null outpoint if the name
+   * is not being updated at the moment.
    */
-  inline void
+  COutPoint lastNameOutput (const valtype& name) const;
+
+  /**
+   * Clears all data.
+   */
+  void
   clear ()
   {
     mapNameRegs.clear ();
-    mapNameUpdates.clear ();
+    updates.clear ();
     mapNameNews.clear ();
   }
 
   /**
-   * Add an entry without checking it.  It should have been checked
+   * Adds an entry without checking it.  It should have been checked
    * already.  If this conflicts with the mempool, it may throw.
    */
   void addUnchecked (const CTxMemPoolEntry& entry);
 
   /**
-   * Remove the given mempool entry.  It is assumed that it is present.
-   * @param entry The entry to remove.
+   * Removes the given mempool entry.  It is assumed that it is present.
    */
   void remove (const CTxMemPoolEntry& entry);
 
   /**
-   * Remove conflicts for the given tx, based on name operations.  I. e.,
+   * Removes conflicts for the given tx, based on name operations.  I.e.,
    * if the tx registers a name that conflicts with another registration
    * in the mempool, detect this and remove the mempool tx accordingly.
-   * @param tx The transaction for which we look for conflicts.
-   * @param removed Put removed tx here.
    */
   void removeConflicts (const CTransaction& tx);
 
   /**
-   * Remove conflicts in the mempool due to unexpired names.  This removes
+   * Removes conflicts in the mempool due to unexpired names.  This removes
    * conflicting name registrations that are no longer possible.
-   * @param unexpired The set of unexpired names.
-   * @param removed Put removed tx here.
    */
   void removeUnexpireConflicts (const std::set<valtype>& unexpired);
   /**
-   * Remove conflicts in the mempool due to expired names.  This removes
+   * Removes conflicts in the mempool due to expired names.  This removes
    * conflicting name updates that are no longer possible.
-   * @param expired The set of expired names.
-   * @param removed Put removed tx here.
    */
   void removeExpireConflicts (const std::set<valtype>& expired);
 
   /**
-   * Perform sanity checks.  Throws if it fails.
-   * @param coins The coins view this represents.
+   * Performs sanity checks.  Throws if it fails.
    */
   void check (const CCoinsView& coins) const;
 
   /**
-   * Check if a tx can be added (based on name criteria) without
+   * Checks if a tx can be added (based on name criteria) without
    * causing a conflict.
-   * @param tx The transaction to check.
-   * @return True if it doesn't conflict.
    */
   bool checkTx (const CTransaction& tx) const;
 

--- a/src/names/mempool.h
+++ b/src/names/mempool.h
@@ -86,14 +86,6 @@ public:
   }
 
   /**
-   * Return txid of transaction registering or updating a name.  The returned
-   * txid is null if no such tx exists.
-   * @param name The name to check for.
-   * @return The txid that registers/updates it.  Null if none.
-   */
-  uint256 getTxForName (const valtype& name) const;
-
-  /**
    * Clear all data.
    */
   inline void

--- a/src/test/name_mempool_tests.cpp
+++ b/src/test/name_mempool_tests.cpp
@@ -240,24 +240,6 @@ BOOST_FIXTURE_TEST_CASE (name_update, NameMempoolTestSetup)
   BOOST_CHECK (mempool.checkNameOps (tx2));
 }
 
-BOOST_FIXTURE_TEST_CASE (getTxForName, NameMempoolTestSetup)
-{
-  BOOST_CHECK (mempool.getTxForName (Name ("new")).IsNull ());
-  BOOST_CHECK (mempool.getTxForName (Name ("reg")).IsNull ());
-  BOOST_CHECK (mempool.getTxForName (Name ("upd")).IsNull ());
-
-  const auto txReg = Tx (FirstScript (ADDR, "reg", 'a'));
-  const auto txUpd = Tx (UpdateScript (ADDR, "upd", "x"));
-
-  mempool.addUnchecked (Entry (Tx (NewScript (ADDR, "new", 'a'))));
-  mempool.addUnchecked (Entry (txReg));
-  mempool.addUnchecked (Entry (txUpd));
-
-  BOOST_CHECK (mempool.getTxForName (Name ("new")).IsNull ());
-  BOOST_CHECK (mempool.getTxForName (Name ("reg")) == txReg.GetHash ());
-  BOOST_CHECK (mempool.getTxForName (Name ("upd")) == txUpd.GetHash ());
-}
-
 BOOST_FIXTURE_TEST_CASE (mempool_sanity_check, NameMempoolTestSetup)
 {
   mempool.addUnchecked (Entry (Tx (NewScript (ADDR, "new", 'a'))));

--- a/src/test/name_mempool_tests.cpp
+++ b/src/test/name_mempool_tests.cpp
@@ -175,6 +175,56 @@ BOOST_FIXTURE_TEST_CASE (empty_mempool, NameMempoolTestSetup)
   BOOST_CHECK (mempool.checkNameOps (Tx (UpdateScript (ADDR, "foo", "y"))));
 }
 
+BOOST_FIXTURE_TEST_CASE (lastNameOutput, NameMempoolTestSetup)
+{
+  const auto txNew = Tx (NewScript (ADDR, "new", 'a'));
+  const auto txReg = Tx (FirstScript (ADDR, "reg", 'b'));
+  const auto txUpd = Tx (UpdateScript (ADDR, "upd", "x"));
+
+  mempool.addUnchecked (Entry (txNew));
+  mempool.addUnchecked (Entry (txReg));
+  mempool.addUnchecked (Entry (txUpd));
+
+  /* For testing chained name updates, we have to build a "real" chain of
+     transactions with matching inputs and outputs.  */
+
+  CMutableTransaction mtx;
+  mtx.SetNamecoin ();
+  mtx.vout.push_back (CTxOut (COIN, FirstScript (ADDR, "chain", 'a')));
+  mtx.vout.push_back (CTxOut (COIN, ADDR));
+  mtx.vout.push_back (CTxOut (COIN, OTHER_ADDR));
+  const CTransaction chain1(mtx);
+  mempool.addUnchecked (Entry (chain1));
+
+  mtx.vout.clear ();
+  mtx.vout.push_back (CTxOut (COIN, ADDR));
+  mtx.vout.push_back (CTxOut (COIN, UpdateScript (ADDR, "chain", "x")));
+  mtx.vin.push_back (CTxIn (COutPoint (chain1.GetHash (), 0)));
+  const CTransaction chain2(mtx);
+  mempool.addUnchecked (Entry (chain2));
+
+  mtx.vout.clear ();
+  mtx.vout.push_back (CTxOut (COIN, OTHER_ADDR));
+  mtx.vout.push_back (CTxOut (COIN, UpdateScript (ADDR, "chain", "y")));
+  mtx.vin.push_back (CTxIn (COutPoint (chain2.GetHash (), 0)));
+  mtx.vin.push_back (CTxIn (COutPoint (chain1.GetHash (), 1)));
+  const CTransaction chain3(mtx);
+  mempool.addUnchecked (Entry (chain3));
+
+  CMutableTransaction mtxCurrency;
+  mtxCurrency.vin.push_back (CTxIn (COutPoint (chain1.GetHash (), 2)));
+  mtxCurrency.vin.push_back (CTxIn (COutPoint (chain3.GetHash (), 0)));
+  mempool.addUnchecked (Entry (CTransaction (mtxCurrency)));
+
+  BOOST_CHECK (mempool.lastNameOutput (Name ("new")).IsNull ());
+  BOOST_CHECK (mempool.lastNameOutput (Name ("reg"))
+                  == COutPoint (txReg.GetHash (), 0));
+  BOOST_CHECK (mempool.lastNameOutput (Name ("upd"))
+                  == COutPoint (txUpd.GetHash (), 0));
+  BOOST_CHECK (mempool.lastNameOutput (Name ("chain"))
+                  == COutPoint (chain3.GetHash (), 1));
+}
+
 BOOST_FIXTURE_TEST_CASE (name_new, NameMempoolTestSetup)
 {
   const auto tx1 = Tx (NewScript (ADDR, "foo", 'a'));
@@ -224,20 +274,32 @@ BOOST_FIXTURE_TEST_CASE (name_update, NameMempoolTestSetup)
 {
   const auto tx1 = Tx (UpdateScript (ADDR, "foo", "x"));
   const auto tx2 = Tx (UpdateScript (ADDR, "foo", "y"));
+  const auto tx3 = Tx (UpdateScript (ADDR, "bar", "z"));
 
-  const auto e = Entry (tx1);
-  BOOST_CHECK (!e.isNameRegistration () && e.isNameUpdate ());
-  BOOST_CHECK (e.getName () == Name ("foo"));
+  const auto e1 = Entry (tx1);
+  const auto e2 = Entry (tx2);
+  const auto e3 = Entry (tx3);
+  BOOST_CHECK (!e1.isNameRegistration () && e1.isNameUpdate ());
+  BOOST_CHECK (e1.getName () == Name ("foo"));
 
-  mempool.addUnchecked (e);
+  mempool.addUnchecked (e1);
+  mempool.addUnchecked (e2);
+  mempool.addUnchecked (e3);
   BOOST_CHECK (!mempool.registersName (Name ("foo")));
   BOOST_CHECK (mempool.updatesName (Name ("foo")));
-  BOOST_CHECK (!mempool.checkNameOps (tx2));
+  BOOST_CHECK (mempool.updatesName (Name ("bar")));
+
+  mempool.removeRecursive (tx2);
+  BOOST_CHECK (mempool.updatesName (Name ("foo")));
+  BOOST_CHECK (mempool.updatesName (Name ("bar")));
 
   mempool.removeRecursive (tx1);
   BOOST_CHECK (!mempool.updatesName (Name ("foo")));
-  BOOST_CHECK (mempool.checkNameOps (tx1));
-  BOOST_CHECK (mempool.checkNameOps (tx2));
+  BOOST_CHECK (mempool.updatesName (Name ("bar")));
+
+  mempool.removeRecursive (tx3);
+  BOOST_CHECK (!mempool.updatesName (Name ("foo")));
+  BOOST_CHECK (!mempool.updatesName (Name ("bar")));
 }
 
 BOOST_FIXTURE_TEST_CASE (mempool_sanity_check, NameMempoolTestSetup)
@@ -246,10 +308,13 @@ BOOST_FIXTURE_TEST_CASE (mempool_sanity_check, NameMempoolTestSetup)
   mempool.addUnchecked (Entry (Tx (NewScript (ADDR, "new", 'b'))));
 
   mempool.addUnchecked (Entry (Tx (FirstScript (ADDR, "reg", 'a'))));
+  mempool.addUnchecked (Entry (Tx (UpdateScript (ADDR, "reg", "n"))));
+
   mempool.addUnchecked (Entry (Tx (UpdateScript (ADDR, "upd", "x"))));
+  mempool.addUnchecked (Entry (Tx (UpdateScript (ADDR, "upd", "y"))));
 
   CCoinsViewCache view(pcoinsTip.get());
-  const CNameScript nameOp(UpdateScript (ADDR, "upd", "y"));
+  const CNameScript nameOp(UpdateScript (ADDR, "upd", "o"));
   CNameData data;
   data.fromScript (100, COutPoint (uint256 (), 0), nameOp);
   view.SetName (Name ("upd"), data, false);
@@ -280,17 +345,21 @@ BOOST_FIXTURE_TEST_CASE (registration_conflicts, NameMempoolTestSetup)
 
 BOOST_FIXTURE_TEST_CASE (expire_conflicts, NameMempoolTestSetup)
 {
-  const auto tx = Tx (UpdateScript (ADDR, "foo", "x"));
-  const auto e = Entry (tx);
+  const auto tx1 = Tx (UpdateScript (ADDR, "foo", "x"));
+  const auto tx2 = Tx (UpdateScript (ADDR, "foo", "y"));
+  const auto e1 = Entry (tx1);
+  const auto e2 = Entry (tx2);
 
-  mempool.addUnchecked (e);
+  mempool.addUnchecked (e1);
+  mempool.addUnchecked (e2);
   BOOST_CHECK (mempool.updatesName (Name ("foo")));
 
   CNameConflictTracker tracker(mempool);
   mempool.removeExpireConflicts ({Name ("foo")});
-  BOOST_CHECK (tracker.GetNameConflicts ()->size () == 1);
-  BOOST_CHECK (tracker.GetNameConflicts ()->front ()->GetHash ()
-                == tx.GetHash ());
+  const auto& conflicts = *tracker.GetNameConflicts ();
+  BOOST_CHECK (conflicts.size () == 2);
+  BOOST_CHECK (conflicts[0]->GetHash () == tx1.GetHash ());
+  BOOST_CHECK (conflicts[1]->GetHash () == tx2.GetHash ());
 
   BOOST_CHECK (!mempool.updatesName (Name ("foo")));
   BOOST_CHECK (mempool.mapTx.empty ());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -755,6 +755,13 @@ public:
         return names.updatesName(name);
     }
 
+    COutPoint
+    lastNameOutput(const valtype& name) const
+    {
+        AssertLockHeld(cs);
+        return names.lastNameOutput(name);
+    }
+
     /**
      * Check if a tx can be added to it according to name criteria.
      * (The non-name criteria are checked in main.cpp and not here, we

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -741,23 +741,18 @@ public:
         return (mapTx.count(hash) != 0);
     }
 
-    inline bool
+    bool
     registersName(const valtype& name) const
     {
         AssertLockHeld(cs);
         return names.registersName(name);
     }
-    inline bool
+
+    bool
     updatesName(const valtype& name) const
     {
         AssertLockHeld(cs);
         return names.updatesName(name);
-    }
-    inline uint256
-    getTxForName (const valtype& name) const
-    {
-        AssertLockHeld(cs);
-        return names.getTxForName(name);
     }
 
     /**

--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -655,25 +655,38 @@ name_update (const JSONRPCRequest& request)
   if (value.size () > MAX_VALUE_LENGTH_UI)
     throw JSONRPCError (RPC_INVALID_PARAMETER, "the value is too long");
 
-  /* Reject updates to a name for which the mempool already has
-     a pending update.  This is not a hard rule enforced by network
-     rules, but it is necessary with the current mempool implementation.  */
+  /* For finding the name output to spend, we first check if there are
+     pending operations on the name in the mempool.  If there are, then we
+     build upon the last one to get a valid chain.  If there are none, then we
+     look up the last outpoint from the name database instead.  */
+
+  COutPoint outp;
   {
     LOCK (mempool.cs);
-    if (mempool.updatesName (name))
+    outp = mempool.lastNameOutput (name);
+
+    /* TODO:  For now, we disallow chained updates.  The mempool accepts them,
+       but until most relaying nodes and miners have updated to accept them
+       as well, we should not create them through the wallet.  Once the network
+       is sufficiently updated, remove this restriction.  */
+    if (!outp.IsNull ())
       throw JSONRPCError (RPC_TRANSACTION_ERROR,
-                          "there is already a pending update for this name");
+                          "there is already a pending operation for this name");
   }
 
-  CNameData oldData;
-  {
-    LOCK (cs_main);
-    if (!pcoinsTip->GetName (name, oldData) || oldData.isExpired ())
-      throw JSONRPCError (RPC_TRANSACTION_ERROR,
-                          "this name can not be updated");
-  }
+  if (outp.IsNull ())
+    {
+      LOCK (cs_main);
 
-  const COutPoint outp = oldData.getUpdateOutpoint ();
+      CNameData oldData;
+      if (!pcoinsTip->GetName (name, oldData) || oldData.isExpired ())
+        throw JSONRPCError (RPC_TRANSACTION_ERROR,
+                            "this name can not be updated");
+
+      outp = oldData.getUpdateOutpoint ();
+    }
+
+  assert (!outp.IsNull ());
   const CTxIn txIn(outp);
 
   /* Make sure the results are valid at least up to the most recent block

--- a/test/functional/name_registration.py
+++ b/test/functional/name_registration.py
@@ -154,16 +154,6 @@ class NameRegistrationTest (NameTestFramework):
     assert_raises_rpc_error (-4, 'Input tx not found in wallet',
                              self.nodes[0].name_update, "test-name", "stolen?")
 
-    # Reject update when another update is pending.
-    self.nodes[1].name_update ("test-name", "value")
-    assert_raises_rpc_error (-25, 'is already a pending update for this name',
-                             self.nodes[1].name_update,
-                             "test-name", "new value")
-    self.generate (0, 1)
-    data = self.checkName (0, "test-name", "value", 30, False)
-    self.checkNameHistory (1, "test-name", ["test-value", "x" * 520, "sent",
-                                            "updated", "value"])
-    
     # Update failing after expiry.  Re-registration possible.
     self.checkName (1, "node-1", "x" * 520, None, True)
     assert_raises_rpc_error (-25, 'this name can not be updated',


### PR DESCRIPTION
This removes the mempool-restriction of allowing only one update per name and block.  That restriction was introduced originally to simplify the mempool implementation, but is actually easy to lift.

With this change, we allow a chain of updates of one name to be in the mempool at once; this can be useful e.g. to quickly fix an erraneous previous update without the need to wait for confirmations in between.  For `name_new` and `name_firstupdate`, no changes are made.  Only updates are allowed to be chained on a pending operation, although updates can be chained to a `name_firstupdate`.

Note that the consensus layer of Namecoin already allows such chains, and the restriction lifted is purely a policy one (in other words, this is not a fork of any sort).  For now, we only remove the restriction from the mempool itself; the `name_update` RPC method still won't allow creating such chains.  We will remove the RPC restriction in a second step later on, once miners and nodes have updated to the new policy so that such chains of updates can actually be expected to be relayed and mined.

This mostly resolves #304, except that we will have to remove the RPC restriction at a later point in time as well.