### PR TITLE
Docs: Link to new namecoin-core-docs repo

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -1,4 +1,4 @@
 Gitian building
 ================
 
-This file was moved to [the Bitcoin Core documentation repository](https://github.com/bitcoin-core/docs/blob/master/gitian-building.md) at [https://github.com/bitcoin-core/docs](https://github.com/bitcoin-core/docs).
+This file was moved to [the Namecoin Core documentation repository](https://github.com/namecoin/namecoin-core-docs/blob/master/gitian-building.md) at [https://github.com/namecoin/namecoin-core-docs](https://github.com/namecoin/namecoin-core-docs).


### PR DESCRIPTION
The use of Bitcoin Core's docs repo was confusing some users; this PR links to a new Namecoin fork of that repo instead.