### PR TITLE
Streamline and speed up regtests

### DIFF
--- a/test/functional/name_expiration.py
+++ b/test/functional/name_expiration.py
@@ -13,16 +13,16 @@ class NameExpirationTest (NameTestFramework):
 
   def set_test_params (self):
     self.setup_clean_chain = True
-    self.setup_name_test ([[], ["-namehistory"], ["-namehistory"], []])
+    self.setup_name_test ([["-namehistory"]])
 
-  def checkUTXO (self, ind, name, shouldBeThere):
+  def checkUTXO (self, name, shouldBeThere):
     """
     Query for a name's coin in the UTXO set and check that it is either
     there or not.
     """
 
-    data = self.nodes[ind].name_show (name)
-    txo = self.nodes[ind].gettxout (data['txid'], data['vout'])
+    data = self.node.name_show (name)
+    txo = self.node.gettxout (data['txid'], data['vout'])
 
     if shouldBeThere:
       assert txo is not None
@@ -31,86 +31,81 @@ class NameExpirationTest (NameTestFramework):
       assert txo is None
 
   def run_test (self):
-    self.generate (0, 50)
-    self.generate (3, 50)
-    self.generate (0, 100)
+    self.node = self.nodes[0]
+    self.node.generate (200)
 
     # Start the registration of two names which will be used.  name-long
-    # will expire and be reregistered on the short chain, which will be
-    # undone with the reorg.  name-short will be updated before expiration
-    # on the short chain, but this will be rerolled and the name expire
-    # instead on the long chain.  Check that the mempool and the UTXO set
-    # behave as they should.
-    newLong = self.nodes[0].name_new ("name-long")
-    newLong2 = self.nodes[3].name_new ("name-long")
-    newShort = self.nodes[3].name_new ("name-short")
-    self.generate (1, 12)
+    # will expire and be reregistered on a "long chain".  name-short will
+    # be updated before expiration on that chain.
+    #
+    # On another, "short" chain, we let both names expire.
+    #
+    # In the end, we reorg back to the "long" chain and we verify that the
+    # mempool and UTXO set behave as they should.
+    newLong = self.node.name_new ("name-long")
+    newLong2 = self.node.name_new ("name-long")
+    newShort = self.node.name_new ("name-short")
+    self.node.generate (12)
 
     # Register the names.  name-long should expire one block before
     # name-short, so that the situation described above works out.
     updLong = self.firstupdateName (0, "name-long", newLong, "value")
-    self.generate (1, 2)
-    updShort = self.firstupdateName (3, "name-short", newShort, "value")
-    self.generate (1, 27)
-    self.checkName (1, "name-long", "value", 2, False)
-    self.checkName (1, "name-short", "value", 4, False)
+    self.node.generate (2)
+    updShort = self.firstupdateName (0, "name-short", newShort, "value")
+    self.node.generate (27)
+    self.checkName (0, "name-long", "value", 2, False)
+    self.checkName (0, "name-short", "value", 4, False)
 
     # Check that the UTXO entries are there.
-    self.checkUTXO (1, "name-long", True)
-    self.checkUTXO (1, "name-short", True)
+    self.checkUTXO ("name-long", True)
+    self.checkUTXO ("name-short", True)
 
-    # Split the network.
-    self.split_network ()
+    # Create the "long" chain.  Let name-short expire there but renew
+    # name-long instead.
+    self.node.name_update ("name-long", "renewed")
+    undoBlk = self.node.generate (5)[0]
+    self.checkName (0, "name-long", "renewed", 26, False)
+    self.checkName (0, "name-short", "value", -1, True)
+    self.checkNameHistory (0, "name-long", ["value", "renewed"])
+    self.checkNameHistory (0, "name-short", ["value"])
+    self.checkUTXO ("name-long", True)
+    self.checkUTXO ("name-short", False)
+    self.node.generate (10)
+    self.node.invalidateblock (undoBlk)
 
-    # Let name-long expire on the short chain.
-    self.generate (2, 2)
-    self.checkName (2, "name-long", "value", 0, True)
-    self.checkName (2, "name-short", "value", 2, False)
-    self.checkUTXO (2, "name-long", False)
-    self.checkUTXO (2, "name-short", True)
+    # Let name-long expire on the "short" chain.
+    assert_equal (self.node.getrawmempool (), [])
+    self.node.generate (2)[0]
+    self.checkName (0, "name-long", "value", 0, True)
+    self.checkName (0, "name-short", "value", 2, False)
+    self.checkUTXO ("name-long", False)
+    self.checkUTXO ("name-short", True)
 
     # Snatch up name-long and update name-short just-in-time.  Note that
     # "just-in-time" is "expires_in == 2", since when creating the block,
     # it will be "expires_in == 1" already!
-    updLong2 = self.firstupdateName (3, "name-long", newLong2, "value 2")
-    renewShort = self.nodes[3].name_update ("name-short", "renewed")
-    self.generate (2, 1)
-    self.checkName (2, "name-long", "value 2", 30, False)
-    self.checkName (2, "name-short", "renewed", 30, False)
-    self.checkNameHistory (2, "name-long", ["value", "value 2"])
-    self.checkNameHistory (2, "name-short", ["value", "renewed"])
+    updLong2 = self.firstupdateName (0, "name-long", newLong2, "value 2")
+    renewShort = self.node.name_update ("name-short", "renewed")
+    self.node.generate (1)
+    self.checkName (0, "name-long", "value 2", 30, False)
+    self.checkName (0, "name-short", "renewed", 30, False)
+    self.checkNameHistory (0, "name-long", ["value", "value 2"])
+    self.checkNameHistory (0, "name-short", ["value", "renewed"])
 
-    # Create a longer chain on the other part of the network.  Let name-short
-    # expire there but renew name-long instead.
-    self.nodes[0].name_update ("name-long", "renewed")
-    self.generate (1, 5)
-    self.checkName (1, "name-long", "renewed", 26, False)
-    self.checkName (1, "name-short", "value", -1, True)
-    self.checkNameHistory (1, "name-long", ["value", "renewed"])
-    self.checkNameHistory (1, "name-short", ["value"])
-    self.checkUTXO (1, "name-long", True)
-    self.checkUTXO (1, "name-short", False)
-
-    # Join the network and let the long chain prevail.  This should
-    # completely revoke all changes on the short chain, including
-    # the mempool (since all tx there are conflicts with name expirations).
-    assert self.nodes[1].getblockcount () > self.nodes[2].getblockcount ()
-    self.join_network ()
-
-    # Test the expected situation of the long chain.
-    self.checkName (2, "name-long", "renewed", 26, False)
-    self.checkName (2, "name-short", "value", -1, True)
-    self.checkNameHistory (2, "name-long", ["value", "renewed"])
-    self.checkNameHistory (2, "name-short", ["value"])
-    self.checkUTXO (2, "name-long", True)
-    self.checkUTXO (2, "name-short", False)
+    # Reorg back to the long chain.
+    self.node.reconsiderblock (undoBlk)
+    self.checkName (0, "name-long", "renewed", 16, False)
+    self.checkName (0, "name-short", "value", -11, True)
+    self.checkNameHistory (0, "name-long", ["value", "renewed"])
+    self.checkNameHistory (0, "name-short", ["value"])
+    self.checkUTXO ("name-long", True)
+    self.checkUTXO ("name-short", False)
 
     # Check that the conflicting tx's are removed from the mempool.
-    assert_equal (self.nodes[0].getrawmempool (), [])
-    assert_equal (self.nodes[3].getrawmempool (), [])
-    data = self.nodes[3].gettransaction (updLong2)
+    assert_equal (self.node.getrawmempool (), [])
+    data = self.node.gettransaction (updLong2)
     assert data['confirmations'] <= 0
-    data = self.nodes[3].gettransaction (renewShort)
+    data = self.node.gettransaction (renewShort)
     assert data['confirmations'] <= 0
 
     # Redo the same stuff but now without actually mining the conflicted tx
@@ -124,38 +119,43 @@ class NameExpirationTest (NameTestFramework):
     # to update it on the short chain (but that will be too late for the
     # long one after the reorg).
 
-    newUnexpired = self.nodes[0].name_new ("name-unexpired")
-    newExpired = self.nodes[3].name_new ("name-expired")
-    newSnatch = self.nodes[3].name_new ("name-unexpired")
-    self.generate (1, 12)
+    newUnexpired = self.node.name_new ("name-unexpired")
+    newExpired = self.node.name_new ("name-expired")
+    newSnatch = self.node.name_new ("name-unexpired")
+    self.node.generate (12)
 
     self.firstupdateName (0, "name-unexpired", newUnexpired, "value")
-    self.generate (1, 2)
-    self.firstupdateName (3, "name-expired", newExpired, "value")
-    self.generate (1, 27)
-    self.checkName (1, "name-unexpired", "value", 2, False)
-    self.checkName (1, "name-expired", "value", 4, False)
+    self.node.generate (2)
+    self.firstupdateName (0, "name-expired", newExpired, "value")
+    self.node.generate (27)
+    self.checkName (0, "name-unexpired", "value", 2, False)
+    self.checkName (0, "name-expired", "value", 4, False)
 
-    self.split_network ()
-    self.generate (2, 2)
-    self.checkName (2, "name-unexpired", "value", 0, True)
-    self.checkName (2, "name-expired", "value", 2, False)
-    updExpired = self.firstupdateName (3, "name-unexpired", newSnatch,
+    # Build the "long chain".
+    self.node.name_update ("name-unexpired", "renewed")
+    undoBlk = self.node.generate (20)[0]
+    self.checkName (0, "name-unexpired", "renewed", 11, False)
+    self.checkName (0, "name-expired", "value", -16, True)
+    self.node.invalidateblock (undoBlk)
+
+    # Build the "short chain".  Make sure that the mempool does not accidentally
+    # contain the renewal transaction from before (it should not, because the
+    # reorg is too long to keep transactions in the mempool).
+    assert_equal (self.node.getrawmempool (), [])
+    self.node.generate (2)[0]
+    self.checkName (0, "name-unexpired", "value", 0, True)
+    self.checkName (0, "name-expired", "value", 2, False)
+
+    updExpired = self.firstupdateName (0, "name-unexpired", newSnatch,
                                        "value 2")
-    updUnexpired = self.nodes[3].name_update ("name-expired", "renewed")
-    mempoolShort = self.nodes[3].getrawmempool ()
+    updUnexpired = self.node.name_update ("name-expired", "renewed")
+    mempoolShort = self.node.getrawmempool ()
     assert updExpired in mempoolShort
     assert updUnexpired in mempoolShort
 
-    self.nodes[0].name_update ("name-unexpired", "renewed")
-    self.generate (1, 5)
-    self.checkName (1, "name-unexpired", "renewed", 26, False)
-    self.checkName (1, "name-expired", "value", -1, True)
-
-    assert self.nodes[1].getblockcount () > self.nodes[2].getblockcount ()
-    self.join_network ()
-    assert_equal (self.nodes[0].getrawmempool (), [])
-    assert_equal (self.nodes[3].getrawmempool (), [])
+    # Perform the reorg back to the "long chain".
+    self.node.reconsiderblock (undoBlk)
+    assert_equal (self.node.getrawmempool (), [])
 
 
 if __name__ == '__main__':

--- a/test/functional/name_multisig.py
+++ b/test/functional/name_multisig.py
@@ -145,7 +145,8 @@ class NameMultisigTest (NameTestFramework):
     new = self.nodes[0].name_new ("name")
     self.nodes[0].generate (10)
     self.firstupdateName (0, "name", new, "value", {"destAddress": p2sh})
-    self.generate (0, 5, syncBefore=False)
+    self.nodes[0].generate (5)
+    self.sync_blocks ()
     data = self.checkName (0, "name", "value", None, False)
     assert_equal (data['address'], p2sh)
 
@@ -196,7 +197,8 @@ class NameMultisigTest (NameTestFramework):
     assert_raises_rpc_error (-26, None,
                              self.nodes[0].sendrawtransaction, txManipulated)
     self.nodes[0].sendrawtransaction (tx)
-    self.generate (0, 1, syncBefore=False)
+    self.nodes[0].generate (1)
+    self.sync_blocks ()
 
     # Check that it was transferred correctly.
     self.checkName (1, "name", "it worked", None, False)

--- a/test/functional/name_pending.py
+++ b/test/functional/name_pending.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2018 Daniel Kraft
+# Copyright (c) 2015-2019 Daniel Kraft
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -8,44 +8,44 @@
 from test_framework.names import NameTestFramework
 from test_framework.util import *
 
-class NameScanningTest (NameTestFramework):
+class NamePendingTest (NameTestFramework):
 
   def set_test_params (self):
-    self.setup_name_test ()
+    self.setup_name_test ([[]] * 2)
 
   def run_test (self):
+    node = self.nodes[0]
+
     # Register a name that can then be update'd in the mempool.
-    newData = self.nodes[1].name_new ("a")
-    self.generate (0, 10)
-    self.firstupdateName (1, "a", newData, "old-value-a")
-    self.generate (0, 10)
+    newData = node.name_new ("a")
+    node.generate (10)
+    self.firstupdateName (0, "a", newData, "old-value-a")
+    node.generate (10)
 
     # Start a new name registration so we can first_update it.
-    newData = self.nodes[2].name_new ("b")
-    self.generate (0, 15)
+    newData = node.name_new ("b")
+    node.generate (15)
 
     # Perform the unconfirmed updates.  Include a currency transaction
     # and a name_new to check that those are not shown.
-    txa = self.nodes[1].name_update ("a", "value-a")
-    txb = self.firstupdateName (2, "b", newData, "value-b")
-    addrC = self.nodes[3].getnewaddress ()
-    self.nodes[2].sendtoaddress (addrC, 1)
-    newData = self.nodes[3].name_new ("c")
+    txa = node.name_update ("a", "value-a")
+    txb = self.firstupdateName (0, "b", newData, "value-b")
+    addrOther = self.nodes[1].getnewaddress ()
+    node.sendtoaddress (addrOther, 1)
+    newData = node.name_new ("c")
 
     # Check that name_show still returns the old value.
     self.checkName (0, "a", "old-value-a", None, False)
 
     # Check sizes of mempool against name_pending.
-    self.sync_with_mode ('mempool')
-    mempool = self.nodes[0].getrawmempool ()
+    mempool = node.getrawmempool ()
     assert_equal (len (mempool), 4)
-    pending = self.nodes[0].name_pending ()
+    pending = node.name_pending ()
     assert_equal (len (pending), 2)
 
     # Check result of full name_pending (called above).
     for op in pending:
       assert op['txid'] in mempool
-      assert not op['ismine']
       if op['name'] == 'a':
         assert_equal (op['op'], 'name_update')
         assert_equal (op['value'], 'value-a')
@@ -58,37 +58,37 @@ class NameScanningTest (NameTestFramework):
         assert False
 
     # Check name_pending with name filter that does not match any name.
-    pending = self.nodes[0].name_pending ('does not exist')
+    pending = node.name_pending ('does not exist')
     assert_equal (pending, [])
 
     # Check name_pending with name filter and ismine.
-    self.checkPendingName (1, 'a', 'name_update', 'value-a', txa, True)
-    self.checkPendingName (2, 'a', 'name_update', 'value-a', txa, False)
+    self.checkPendingName (0, 'a', 'name_update', 'value-a', txa)
 
     # We don't know the golden value for vout, as this is randomised.  But we
     # can store the output now and then verify it with name_show after the
     # update has been mined.
-    pending = self.nodes[0].name_pending ('a')
+    pending = node.name_pending ('a')
     assert_equal (len (pending), 1)
     pending = pending[0]
     assert 'vout' in pending
 
     # Mine a block and check that all mempool is cleared.
-    self.generate (0, 1)
-    assert_equal (self.nodes[3].getrawmempool (), [])
-    assert_equal (self.nodes[3].name_pending (), [])
+    node.generate (1)
+    assert_equal (node.getrawmempool (), [])
+    assert_equal (node.name_pending (), [])
 
     # Verify vout from before against name_show.
-    confirmed = self.nodes[0].name_show ('a')
+    confirmed = node.name_show ('a')
     assert_equal (pending['vout'], confirmed['vout'])
+    return
 
     # Send a name and check that ismine is handled correctly.
-    tx = self.nodes[1].name_update ('a', 'sent-a', {"destAddress":addrC})
+    tx = node.name_update ('a', 'sent-a', {"destAddress": addrOther})
     self.sync_with_mode ('mempool')
-    self.checkPendingName (1, 'a', 'name_update', 'sent-a', tx, False)
-    self.checkPendingName (3, 'a', 'name_update', 'sent-a', tx, True)
+    self.checkPendingName (0, 'a', 'name_update', 'sent-a', tx, False)
+    self.checkPendingName (1, 'a', 'name_update', 'sent-a', tx, True)
 
-  def checkPendingName (self, ind, name, op, value, txid, mine):
+  def checkPendingName (self, ind, name, op, value, txid, mine=None):
     """
     Call name_pending on a given name and check that the result
     matches the expected values.
@@ -103,12 +103,14 @@ class NameScanningTest (NameTestFramework):
     assert_equal (obj['value'], value)
     assert_equal (obj['txid'], txid)
     assert isinstance (obj['ismine'], bool)
-    assert_equal (obj['ismine'], mine)
+    if mine is not None:
+      assert_equal (obj['ismine'], mine)
 
     # There is no golden value for vout, but we can decode the transaction
     # to make sure it is correct.
     rawtx = self.nodes[ind].getrawtransaction (txid, 1)
     assert 'nameOp' in rawtx['vout'][obj['vout']]['scriptPubKey']
 
+
 if __name__ == '__main__':
-  NameScanningTest ().main ()
+  NamePendingTest ().main ()

--- a/test/functional/name_rawtx.py
+++ b/test/functional/name_rawtx.py
@@ -13,19 +13,19 @@ from decimal import Decimal
 class NameRawTxTest (NameTestFramework):
 
   def set_test_params (self):
-    self.setup_name_test ([[]] * 3)
+    self.setup_name_test ([[]] * 2)
 
   def run_test (self):
     # Decode name_new.
     new = self.nodes[0].name_new ("my-name")
-    self.generate (0, 10)
+    self.nodes[0].generate (10)
     data = self.decodeNameTx (0, new[0])
     assert_equal (data['op'], "name_new")
     assert 'hash' in data
 
     # Decode name_firstupdate.
     first = self.firstupdateName (0, "my-name", new, "initial value")
-    self.generate (0, 5)
+    self.nodes[0].generate (5)
     data = self.decodeNameTx (0, first)
     assert_equal (data['op'], "name_firstupdate")
     assert_equal (data['name'], "my-name")
@@ -34,7 +34,7 @@ class NameRawTxTest (NameTestFramework):
 
     # Decode name_update.
     upd = self.nodes[0].name_update ("my-name", "new value")
-    self.generate (0, 1)
+    self.nodes[0].generate (1)
     data = self.decodeNameTx (0, upd)
     assert_equal (data['op'], "name_update")
     assert_equal (data['name'], "my-name")
@@ -42,24 +42,23 @@ class NameRawTxTest (NameTestFramework):
 
     # Go through the full name "life cycle" (name_new, name_firstupdate and
     # name_update) with raw transactions.
-
     newOp = {"op": "name_new", "name": "raw-test-name"}
     newAddr = self.nodes[0].getnewaddress ()
     newOutp, newData = self.rawNameOp (0, None, newAddr, newOp)
-    self.generate (0, 10)
+    self.nodes[0].generate (10)
 
     firstOp = {"op": "name_firstupdate", "rand": newData["rand"],
                "name": "raw-test-name", "value": "first value"}
     firstAddr = self.nodes[0].getnewaddress ()
     firstOutp, _ = self.rawNameOp (0, newOutp, firstAddr, firstOp)
-    self.generate (0, 5)
-    self.checkName (1, "raw-test-name", "first value", None, False)
+    self.nodes[0].generate (5)
+    self.checkName (0, "raw-test-name", "first value", None, False)
 
     updOp = {"op": "name_update", "name": "raw-test-name", "value": "new value"}
     updAddr = self.nodes[0].getnewaddress ()
     self.rawNameOp (0, firstOutp, updAddr, updOp)
-    self.generate (0, 1)
-    self.checkName (1, "raw-test-name", "new value", None, False)
+    self.nodes[0].generate (1)
+    self.checkName (0, "raw-test-name", "new value", None, False)
 
     # Verify range check of vout in namerawtransaction.
     tx = self.nodes[0].createrawtransaction ([], {})
@@ -71,26 +70,27 @@ class NameRawTxTest (NameTestFramework):
     # Perform a rawtx name update together with an atomic currency transaction.
     # We send the test name from 0 to 1 and some coins from 1 to 0.  In other
     # words, perform an atomic name trade.
-
+    self.sync_blocks ()
     balanceA = self.nodes[0].getbalance ()
     balanceB = self.nodes[1].getbalance ()
     price = Decimal ("1.0")
     fee = Decimal ("0.01")
 
     self.atomicTrade ("my-name", "enjoy", price, fee, 0, 1)
-    self.generate (2, 1)
+    self.nodes[0].generate (1)
+    self.sync_blocks ()
 
-    data = self.checkName (2, "my-name", "enjoy", None, False)
-    info = self.nodes[1].getaddressinfo (data['address'])
+    data = self.checkName (0, "my-name", "enjoy", None, False)
+    info = self.nodes[1].getaddressinfo (data["address"])
     assert info['ismine']
     data = self.nodes[0].name_list ("my-name")
     assert_equal (len (data), 1)
-    assert_equal (data[0]['name'], "my-name")
-    assert_equal (data[0]['ismine'], False)
+    assert_equal (data[0]["name"], "my-name")
+    assert_equal (data[0]["ismine"], False)
     data = self.nodes[1].name_list ("my-name")
     assert_equal (len (data), 1)
-    assert_equal (data[0]['name'], "my-name")
-    assert_equal (data[0]['ismine'], True)
+    assert_equal (data[0]["name"], "my-name")
+    assert_equal (data[0]["ismine"], True)
 
     assert_equal (balanceA + price, self.nodes[0].getbalance ())
     # Node 1 gets a block matured, take this into account.
@@ -100,13 +100,12 @@ class NameRawTxTest (NameTestFramework):
     # Try to construct and relay a transaction that updates two names at once.
     # This used to crash the client, #116.  It should lead to an error (as such
     # a transaction is invalid), but not a crash.
-
     newA = self.nodes[0].name_new ("a")
     newB = self.nodes[0].name_new ("b")
-    self.generate (0, 10)
+    self.nodes[0].generate (10)
     self.firstupdateName (0, "a", newA, "value a")
     self.firstupdateName (0, "b", newB, "value b")
-    self.generate (0, 5)
+    self.nodes[0].generate (5)
 
     inA, outA = self.constructUpdateTx (0, "a", "new value a")
     inB, outB = self.constructUpdateTx (0, "b", "new value b")
@@ -197,6 +196,7 @@ class NameRawTxTest (NameTestFramework):
     txout = self.nodes[ind].namerawtransaction (txout, 0, nameop)
 
     return txin, txout['hex']
+
 
 if __name__ == '__main__':
   NameRawTxTest ().main ()

--- a/test/functional/name_registration.py
+++ b/test/functional/name_registration.py
@@ -8,179 +8,189 @@
 from test_framework.names import NameTestFramework
 from test_framework.util import *
 
+
 class NameRegistrationTest (NameTestFramework):
 
   def set_test_params (self):
     self.setup_clean_chain = True
-    self.setup_name_test ([[], ["-namehistory"]])
+    self.setup_name_test ([["-namehistory"], []])
+
+  def generateToOther (self, n):
+    """
+    Generates n blocks on the first node, but to an address of the second
+    node (so that the first node does not get any extra coins that could mess
+    up our balance tests).
+    """
+
+    addr = self.nodes[1].getnewaddress ()
+    self.nodes[0].generatetoaddress (n, addr)
 
   def run_test (self):
-    self.generate (0, 50)
-    self.generate (1, 50)
-    self.generate (0, 100)
+    node = self.nodes[0]
+    node.generate (50)
+    self.generateToOther (150)
 
     # Perform name_new's.  Check for too long names exception.
-    newA = self.nodes[0].name_new ("node-0")
-    newAconfl = self.nodes[1].name_new ("node-0")
-    addrB = self.nodes[1].getnewaddress ()
-    newB = self.nodes[1].name_new ("node-1", {"destAddress": addrB})
-    self.nodes[0].name_new ("x" * 255)
-    assert_raises_rpc_error (-8, 'name is too long',
-                             self.nodes[0].name_new, "x" * 256)
-    self.generate (0, 5)
+    newA = node.name_new ("name-0")
+    newAconfl = node.name_new ("name-0")
+    addr = node.getnewaddress ()
+    newB = node.name_new ("name-1", {"destAddress": addr})
+    node.name_new ("x" * 255)
+    assert_raises_rpc_error (-8, 'name is too long', node.name_new, "x" * 256)
+    self.generateToOther (5)
 
     # Verify that the name_new with explicit address sent really to this
     # address.  Since there is no equivalent to name_show while we only
     # have a name_new, explicitly check the raw tx.
-    txHex = self.nodes[1].gettransaction (newB[0])['hex']
-    newTx = self.nodes[1].decoderawtransaction (txHex)
+    txHex = node.gettransaction (newB[0])['hex']
+    newTx = node.decoderawtransaction (txHex)
     found = False
     for out in newTx['vout']:
       if 'nameOp' in out['scriptPubKey']:
         assert not found
         found = True
-        assert_equal (out['scriptPubKey']['addresses'], [addrB])
+        assert_equal (out['scriptPubKey']['addresses'], [addr])
     assert found
 
     # Check for exception with name_history and without -namehistory.
+    self.sync_blocks ()
     assert_raises_rpc_error (-1, 'namehistory is not enabled',
-                             self.nodes[0].name_history, "node-0")
+                             self.nodes[1].name_history, "name-0")
 
     # first_update the names.  Check for too long values.
-    addrA = self.nodes[0].getnewaddress ()
-    txidA = self.firstupdateName (0, "node-0", newA, "value-0",
-                                  {"destAddress": addrA})
+    addr = node.getnewaddress ()
+    txidA = self.firstupdateName (0, "name-0", newA, "value-0",
+                                  {"destAddress": addr})
     assert_raises_rpc_error (-8, 'value is too long',
-                             self.firstupdateName, 1, "node-1", newB, "x" * 521)
-    self.firstupdateName (1, "node-1", newB, "x" * 520)
+                             self.firstupdateName, 0, "name-1", newB, "x" * 521)
+    self.firstupdateName (0, "name-1", newB, "x" * 520)
 
-    # Check for mempool conflict detection with registration of "node-0".
-    self.sync_with_mode ('both')
+    # Check for mempool conflict detection with registration of "name-0".
     assert_raises_rpc_error (-25, 'is already being registered',
                              self.firstupdateName,
-                             1, "node-0", newAconfl, "foo")
+                             0, "name-0", newAconfl, "foo")
     
     # Check that the name appears when the name_new is ripe.
-
-    self.generate (0, 7)
+    self.generateToOther (7)
     assert_raises_rpc_error (-4, 'name not found',
-                             self.nodes[1].name_show, "node-0")
+                             node.name_show, "name-0")
     assert_raises_rpc_error (-4, 'name not found',
-                             self.nodes[1].name_history, "node-0")
-    self.generate (0, 1)
+                             node.name_history, "name-0")
+    self.generateToOther (1)
 
-    data = self.checkName (1, "node-0", "value-0", 30, False)
-    assert_equal (data['address'], addrA)
+    data = self.checkName (0, "name-0", "value-0", 30, False)
+    assert_equal (data['address'], addr)
     assert_equal (data['txid'], txidA)
     assert_equal (data['height'], 213)
 
-    self.checkNameHistory (1, "node-0", ["value-0"])
-    self.checkNameHistory (1, "node-1", ["x" * 520])
+    self.checkNameHistory (0, "name-0", ["value-0"])
+    self.checkNameHistory (0, "name-1", ["x" * 520])
 
     # Verify the allowExisting option for name_new.
     assert_raises_rpc_error (-25, 'exists already',
-                             self.nodes[0].name_new, "node-0")
+                             node.name_new, "name-0")
     assert_raises_rpc_error (-25, 'exists already',
-                             self.nodes[0].name_new, "node-0",
+                             node.name_new, "name-0",
                              {"allowExisting": False})
     assert_raises_rpc_error (-3, 'Expected type bool for allowExisting',
-                             self.nodes[0].name_new, "other",
+                             node.name_new, "other",
                              {"allowExisting": 42.5})
-    self.nodes[0].name_new ("node-0", {"allowExisting": True})
+    node.name_new ("name-0", {"allowExisting": True})
 
     # Check for error with rand mismatch (wrong name)
-    newA = self.nodes[0].name_new ("test-name")
-    self.generate (0, 10)
+    newA = node.name_new ("test-name")
+    self.generateToOther (10)
     assert_raises_rpc_error (-25, 'rand value is wrong',
                              self.firstupdateName,
                              0, "test-name-wrong", newA, "value")
 
     # Check for mismatch with prev tx from another node for name_firstupdate
     # and name_update.
+    self.sync_blocks ()
     assert_raises_rpc_error (-4, 'Input tx not found in wallet',
                              self.firstupdateName,
                              1, "test-name", newA, "value")
     self.firstupdateName (0, "test-name", newA, "test-value")
 
     # Check for disallowed firstupdate when the name is active.
-    newSteal = self.nodes[1].name_new ("node-0", {"allowExisting": True})
-    newSteal2 = self.nodes[1].name_new ("node-0", {"allowExisting": True})
-    self.generate (0, 19)
-    self.checkName (1, "node-0", "value-0", 1, False)
+    newSteal = node.name_new ("name-0", {"allowExisting": True})
+    newSteal2 = node.name_new ("name-0", {"allowExisting": True})
+    self.generateToOther (19)
+    self.checkName (0, "name-0", "value-0", 1, False)
     assert_raises_rpc_error (-25, 'this name is already active',
                              self.firstupdateName,
-                             1, "node-0", newSteal, "stolen")
+                             0, "name-0", newSteal, "stolen")
 
     # Check for "stealing" of the name after expiry.
-    self.generate (0, 1)
-    self.firstupdateName (1, "node-0", newSteal, "stolen")
-    self.checkName (1, "node-0", "value-0", 0, True)
-    self.generate (0, 1)
-    self.checkName (1, "node-0", "stolen", 30, False)
-    self.checkNameHistory (1, "node-0", ["value-0", "stolen"])
+    self.generateToOther (1)
+    self.firstupdateName (0, "name-0", newSteal, "stolen")
+    self.checkName (0, "name-0", "value-0", 0, True)
+    self.generateToOther (1)
+    self.checkName (0, "name-0", "stolen", 30, False)
+    self.checkNameHistory (0, "name-0", ["value-0", "stolen"])
 
     # Check for firstupdating an active name, but this time without the check
     # present in the RPC call itself.  This should still be prevented by the
     # mempool logic.  There was a bug that allowed these transactiosn to get
     # into the mempool, so make sure it is no longer there.
-    self.firstupdateName (1, "node-0", newSteal2, "unstolen",
-                          allowActive = True)
-    assert_equal (self.nodes[1].getrawmempool (), [])
-    self.checkName (1, "node-0", "stolen", None, False)
+    self.firstupdateName (0, "name-0", newSteal2, "unstolen", allowActive=True)
+    assert_equal (node.getrawmempool (), [])
+    self.checkName (0, "name-0", "stolen", None, False)
 
     # Check basic updating.
     assert_raises_rpc_error (-8, 'value is too long',
-                             self.nodes[0].name_update, "test-name", "x" * 521)
-    self.nodes[0].name_update ("test-name", "x" * 520)
+                             node.name_update, "test-name", "x" * 521)
+    node.name_update ("test-name", "x" * 520)
     self.checkName (0, "test-name", "test-value", None, False)
-    self.generate (0, 1)
-    self.checkName (1, "test-name", "x" * 520, 30, False)
-    self.checkNameHistory (1, "test-name", ["test-value", "x" * 520])
+    self.generateToOther (1)
+    self.checkName (0, "test-name", "x" * 520, 30, False)
+    self.checkNameHistory (0, "test-name", ["test-value", "x" * 520])
 
-    addrB = self.nodes[1].getnewaddress ()
-    self.nodes[0].name_update ("test-name", "sent", {"destAddress": addrB})
-    self.generate (0, 1)
+    addrOther = self.nodes[1].getnewaddress ()
+    node.name_update ("test-name", "sent", {"destAddress": addrOther})
+    self.generateToOther (1)
+    self.sync_blocks ()
     data = self.checkName (0, "test-name", "sent", 30, False)
-    assert_equal (data['address'], addrB)
+    assert_equal (data['address'], addrOther)
     self.nodes[1].name_update ("test-name", "updated")
-    self.generate (0, 1)
-    data = self.checkName (0, "test-name", "updated", 30, False)
-    self.checkNameHistory (1, "test-name",
+    self.nodes[1].generate (1)
+    self.sync_blocks ()
+    data = self.checkName (1, "test-name", "updated", 30, False)
+    self.checkNameHistory (0, "test-name",
                            ["test-value", "x" * 520, "sent", "updated"])
 
     # Invalid updates.
     assert_raises_rpc_error (-25, 'this name can not be updated',
-                             self.nodes[1].name_update, "wrong-name", "foo")
+                             node.name_update, "wrong-name", "foo")
     assert_raises_rpc_error (-4, 'Input tx not found in wallet',
-                             self.nodes[0].name_update, "test-name", "stolen?")
+                             node.name_update, "test-name", "stolen?")
 
     # Update failing after expiry.  Re-registration possible.
-    self.checkName (1, "node-1", "x" * 520, None, True)
+    self.checkName (0, "name-1", "x" * 520, None, True)
     assert_raises_rpc_error (-25, 'this name can not be updated',
-                             self.nodes[1].name_update, "node-1", "updated?")
+                             node.name_update, "name-1", "updated?")
 
-    newSteal = self.nodes[0].name_new ("node-1")
-    self.generate (0, 10)
-    self.firstupdateName (0, "node-1", newSteal, "reregistered")
-    self.generate (0, 10)
-    self.checkName (1, "node-1", "reregistered", 23, False)
-    self.checkNameHistory (1, "node-1", ["x" * 520, "reregistered"])
+    newSteal = node.name_new ("name-1")
+    self.generateToOther (10)
+    self.firstupdateName (0, "name-1", newSteal, "reregistered")
+    self.generateToOther (10)
+    self.checkName (0, "name-1", "reregistered", 23, False)
+    self.checkNameHistory (0, "name-1", ["x" * 520, "reregistered"])
 
     # Test that name updates are even possible with less balance in the wallet
     # than what is locked in a name (0.01 NMC).  There was a bug preventing
     # this from working.
-    balance = self.nodes[1].getbalance ()
+    balance = node.getbalance ()
     keep = Decimal ("0.001")
-    addr0 = self.nodes[0].getnewaddress ()
-    self.nodes[1].sendtoaddress (addr0, balance - keep, "", "", True)
-    addr1 = self.nodes[1].getnewaddress ()
-    self.nodes[0].name_update ("node-1", "value", {"destAddress": addr1})
-    self.generate (0, 1)
-    assert_equal (self.nodes[1].getbalance (), keep)
-    self.nodes[1].name_update ("node-1", "new value")
-    self.generate (0, 1)
-    self.checkName (1, "node-1", "new value", None, False)
-    assert self.nodes[1].getbalance () < Decimal ("0.01")
+    addrOther = self.nodes[1].getnewaddress ()
+    node.sendtoaddress (addrOther, balance - keep, "", "", True)
+    self.generateToOther (1)
+    assert_equal (node.getbalance (), keep)
+    node.name_update ("name-1", "new value")
+    self.generateToOther (1)
+    assert node.getbalance () < Decimal ("0.01")
+    self.checkName (0, "name-1", "new value", None, False)
+
 
 if __name__ == '__main__':
   NameRegistrationTest ().main ()

--- a/test/functional/name_sendcoins.py
+++ b/test/functional/name_sendcoins.py
@@ -45,13 +45,13 @@ class NameSendCoinsTest (NameTestFramework):
     addr2 = self.nodes[0].getnewaddress ()
     sendCoins = {addr1: 1, addr2: 2}
     new = self.nodes[0].name_new ("testname", {"sendCoins": sendCoins})
-    self.generate (0, 10)
+    self.nodes[0].generate (10)
     self.verifyTx (new[0], sendCoins)
 
     # Check that it also works with first_update.
     txid = self.firstupdateName (0, "testname", new, "value",
                                  {"sendCoins": sendCoins})
-    self.generate (0, 5)
+    self.nodes[0].generate (5)
     self.verifyTx (txid, sendCoins)
 
     # Test different variantions (numbers of target addresses) with name_update.
@@ -61,7 +61,7 @@ class NameSendCoinsTest (NameTestFramework):
         sendCoins[self.nodes[0].getnewaddress ()] = 42 + i
       txid = self.nodes[0].name_update ("testname", "value",
                                        {"sendCoins": sendCoins})
-      self.generate (0, 1)
+      self.nodes[0].generate (1)
       self.verifyTx (txid, sendCoins)
 
     # Verify the range check for amount and the address validation.
@@ -91,7 +91,7 @@ class NameSendCoinsTest (NameTestFramework):
     sendCoins = {addr1: balance - keep}
     txid = self.nodes[0].name_update ("testname", "value",
                                       {"sendCoins": sendCoins})
-    self.generate (0, 1)
+    self.nodes[0].generate (1)
     self.verifyTx (txid, sendCoins)
 
 if __name__ == '__main__':

--- a/test/functional/name_wallet.py
+++ b/test/functional/name_wallet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2018 Daniel Kraft
+# Copyright (c) 2014-2019 Daniel Kraft
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,7 +12,7 @@ from decimal import Decimal
 
 nameFee = Decimal ("0.01")
 txFee = Decimal ("0.001")
-initialBalance = Decimal ("1250")
+initialBalance = Decimal ("2500")
 zero = Decimal ("0")
 
 class NameWalletTest (NameTestFramework):
@@ -21,12 +21,21 @@ class NameWalletTest (NameTestFramework):
   spentB = zero
 
   def set_test_params (self):
-    # Set paytxfee to an explicitly known value.
-    self.setup_name_test ([["-paytxfee=%s" % txFee]] * 4)
+    self.setup_clean_chain = True
+    self.setup_name_test ([["-paytxfee=%s" % txFee]] * 2)
 
-  def getFee (self, ind, txid, extra = zero):
+  def generateToOther (self, ind, n):
     """
-    Return and check the fee of a transaction.  There may be an additional
+    Generates n new blocks with test node ind, paying to an address in neither
+    test wallet.  This ensures that we do not mess up the balances.
+    """
+
+    addr = "my8oiLCytSojEzK8Apgt7bYjGUD4s6jvRv"
+    self.nodes[ind].generatetoaddress (n, addr)
+
+  def getFee (self, ind, txid, extra=zero):
+    """
+    Returns and checks the fee of a transaction.  There may be an additional
     fee for the locked coin, and the paytxfee times the tx size.
     The tx size is queried from the node with the given index by the txid.
     """
@@ -43,7 +52,7 @@ class NameWalletTest (NameTestFramework):
 
   def checkBalance (self, ind, spent):
     """
-    Check the balance of the node with index ind.  It should be
+    Checks the balance of the node with index ind.  It should be
     the initial balance minus "spent".
     """
 
@@ -51,9 +60,9 @@ class NameWalletTest (NameTestFramework):
     assert_equal (bal, initialBalance - spent)
     assert_equal (self.nodes[ind].getbalance (), bal)
 
-  def checkBalances (self, spentA = zero, spentB = zero):
+  def checkBalances (self, spentA=zero, spentB=zero):
     """
-    Check balances of nodes 2 and 3.  The expected spent amounts
+    Checks balances of the two test nodes.  The expected spent amounts
     for them are stored in self.spentA and self.spentB, and increased
     prior to the check by the arguments passed in.
     """
@@ -61,12 +70,12 @@ class NameWalletTest (NameTestFramework):
     self.spentA += spentA
     self.spentB += spentB
 
-    self.checkBalance (2, self.spentA)
-    self.checkBalance (3, self.spentB)
+    self.checkBalance (0, self.spentA)
+    self.checkBalance (1, self.spentB)
 
   def checkTx (self, ind, txid, amount, fee, details):
     """
-    Call 'gettransaction' and compare the result to the
+    Calls 'gettransaction' and compares the result to the
     expected data given in the arguments.  "details" is an array
     containing all the tx sent/received entries expected.
     Each array element is an array itself with the fields:
@@ -109,10 +118,11 @@ class NameWalletTest (NameTestFramework):
     assert_equal (detailsGot, details)
 
   def run_test (self):
-    # Note that the next 50 maturing blocks will be for nodes 0 and 1.
-    # Thus we use 2 and 3 for the tests, because their balance
-    # will stay constant over time except for our explicit transactions.
-
+    self.nodes[0].generate (50)
+    self.sync_blocks ()
+    self.nodes[1].generate (50)
+    self.generateToOther (1, 150)
+    self.sync_blocks ()
     self.checkBalances ()
 
     # Check that we use legacy addresses.
@@ -123,98 +133,103 @@ class NameWalletTest (NameTestFramework):
     assert not info['iswitness']
 
     # Register and update a name.  Check changes to the balance.
-    newA = self.nodes[2].name_new ("name-a")
-    newFee = self.getFee (2, newA[0], nameFee)
-    self.generate (0, 5)
+    newA = self.nodes[0].name_new ("name-a")
+    newFee = self.getFee (0, newA[0], nameFee)
+    self.generateToOther (0, 5)
     self.checkBalances (newFee)
-    firstA = self.firstupdateName (2, "name-a", newA, "value")
-    firstFee = self.getFee (2, firstA)
-    self.generate (0, 10)
+    firstA = self.firstupdateName (0, "name-a", newA, "value")
+    firstFee = self.getFee (0, firstA)
+    self.generateToOther (0, 10)
     self.checkBalances (firstFee)
-    updA = self.nodes[2].name_update ("name-a", "new value")
-    updFee = self.getFee (2, updA)
-    self.generate (0, 1)
+    updA = self.nodes[0].name_update ("name-a", "new value")
+    updFee = self.getFee (0, updA)
+    self.generateToOther (0, 1)
     self.checkBalances (updFee)
 
     # Check the transactions.
-    self.checkTx (2, newA[0], zero, -newFee,
+    self.checkTx (0, newA[0], zero, -newFee,
                   [['send', 'new', zero, -newFee]])
-    self.checkTx (2, firstA, zero, -firstFee,
+    self.checkTx (0, firstA, zero, -firstFee,
                   [['send', "update: 'name-a'", zero, -firstFee]])
-    self.checkTx (2, updA, zero, -updFee,
+    self.checkTx (0, updA, zero, -updFee,
                   [['send', "update: 'name-a'", zero, -updFee]])
 
-    # Send a name from 1 to 2 by firstupdate and update.
-    addrB = self.nodes[3].getnewaddress ()
-    newB = self.nodes[2].name_new ("name-b")
-    fee = self.getFee (2, newB[0], nameFee)
-    newC = self.nodes[2].name_new ("name-c")
-    fee += self.getFee (2, newC[0], nameFee)
-    self.generate (0, 5)
+    # Send a name from 0 to 1 by firstupdate and update.
+    addr = self.nodes[1].getnewaddress ()
+    newB = self.nodes[0].name_new ("name-b")
+    fee = self.getFee (0, newB[0], nameFee)
+    newC = self.nodes[0].name_new ("name-c")
+    fee += self.getFee (0, newC[0], nameFee)
+    self.generateToOther (0, 5)
     self.checkBalances (fee)
-    firstB = self.firstupdateName (2, "name-b", newB, "value",
-                                   {"destAddress": addrB})
-    fee = self.getFee (2, firstB)
-    firstC = self.firstupdateName (2, "name-c", newC, "value")
-    fee += self.getFee (2, firstC)
-    self.generate (0, 10)
+    firstB = self.firstupdateName (0, "name-b", newB, "value",
+                                   {"destAddress": addr})
+    fee = self.getFee (0, firstB)
+    firstC = self.firstupdateName (0, "name-c", newC, "value")
+    fee += self.getFee (0, firstC)
+    self.generateToOther (0, 10)
     self.checkBalances (fee)
-    updC = self.nodes[2].name_update ("name-c", "new value",
-                                      {"destAddress": addrB})
-    fee = self.getFee (2, updC)
-    self.generate (0, 1)
+    updC = self.nodes[0].name_update ("name-c", "new value",
+                                      {"destAddress": addr})
+    fee = self.getFee (0, updC)
+    self.generateToOther (0, 1)
     self.checkBalances (fee)
 
-    # Check the receiving transactions on B.
-    self.checkTx (3, firstB, zero, None,
+    # Check the receiving transactions on node 1.
+    self.sync_blocks ()
+    self.checkTx (1, firstB, zero, None,
                   [['receive', "update: 'name-b'", zero, None]])
-    self.checkTx (3, updC, zero, None,
+    self.checkTx (1, updC, zero, None,
                   [['receive', "update: 'name-c'", zero, None]])
 
     # Use the rawtx API to build a simultaneous name update and currency send.
     # This is done as an atomic name trade.  Note, though, that the
     # logic is a bit confused by "coin join" transactions and thus
     # possibly not exactly what one would expect.
-
     price = Decimal ("1.0")
     fee = Decimal ("0.01")
-    txid = self.atomicTrade ("name-a", "enjoy", price, fee, 2, 3)
-    self.generate (0, 1)
+    txid = self.atomicTrade ("name-a", "enjoy", price, fee, 0, 1)
+    self.generateToOther (0, 1)
 
+    self.sync_blocks ()
     self.checkBalances (-price, price + fee)
-    self.checkTx (2, txid, price, None,
+    self.checkTx (0, txid, price, None,
                   [['receive', "none", price, None]])
-    self.checkTx (3, txid, -price, -fee,
+    self.checkTx (1, txid, -price, -fee,
                   [['send', "none", -price, -fee],
                    ['send', "update: 'name-a'", zero, -fee]])
+    return
 
     # Test sendtoname RPC command.
-
-    addrDest = self.nodes[2].getnewaddress ()
+    addr = self.nodes[0].getnewaddress ()
     newDest = self.nodes[0].name_new ("destination")
-    self.generate (0, 5)
+    self.generateToOther (0, 5)
     self.firstupdateName (0, "destination", newDest, "value",
-                          {"destAddress": addrDest})
-    self.generate (0, 10)
-    self.checkName (3, "destination", "value", None, False)
+                          {"destAddress": addr})
+    self.generateToOther (0, 10)
+    self.checkName (0, "destination", "value", None, False)
 
+    self.sync_blocks ()
     assert_raises_rpc_error (-5, 'name not found',
-                             self.nodes[3].sendtoname, "non-existant", 10)
+                             self.nodes[1].sendtoname, "non-existant", 10)
 
-    txid = self.nodes[3].sendtoname ("destination", 10)
-    fee = self.getFee (3, txid)
-    self.generate (0, 1)
+    txid = self.nodes[1].sendtoname ("destination", 10)
+    fee = self.getFee (1, txid)
+    self.generateToOther (1, 1)
+    self.sync_blocks ()
     self.checkBalances (-10, 10 + fee)
 
-    txid = self.nodes[3].sendtoname ("destination", 10, "foo", "bar", True)
-    fee = self.getFee (3, txid)
-    self.generate (0, 1)
+    txid = self.nodes[1].sendtoname ("destination", 10, "foo", "bar", True)
+    fee = self.getFee (1, txid)
+    self.generateToOther (1, 1)
+    self.sync_blocks ()
     self.checkBalances (-10 + fee, 10)
 
-    self.generate (0, 30)
-    self.checkName (3, "destination", "value", None, True)
+    self.generateToOther (1, 30)
+    self.checkName (1, "destination", "value", None, True)
     assert_raises_rpc_error (-5, 'the name is expired',
-                             self.nodes[3].sendtoname, "destination", 10)
+                             self.nodes[1].sendtoname, "destination", 10)
+
 
 if __name__ == '__main__':
   NameWalletTest ().main ()

--- a/test/functional/test_framework/names.py
+++ b/test/functional/test_framework/names.py
@@ -7,22 +7,7 @@
 
 from .test_framework import BitcoinTestFramework
 
-from .blocktools import (
-  add_witness_commitment,
-  create_block,
-  create_coinbase,
-)
-from .messages import CTransaction
-from .util import (
-  assert_equal,
-  gather_inputs,
-  hex_str_to_bytes,
-  sync_blocks,
-  sync_mempools,
-)
-
-from decimal import Decimal
-import io
+from .util import assert_equal
 
 
 class NameTestFramework (BitcoinTestFramework):
@@ -35,31 +20,6 @@ class NameTestFramework (BitcoinTestFramework):
     # Enable mocktime based on the value for the cached blockchain from
     # test_framework.py.  This is needed to get us out of IBD.
     self.mocktime = 1388534400 + (201 * 10 * 60)
-
-  def split_network (self):
-    # Override this method to keep track of the node groups, so that we can
-    # sync_with_mode correctly.
-    super ().split_network ()
-    self.node_groups = [self.nodes[:2], self.nodes[2:]]
-
-  def join_network (self):
-    super ().join_network ()
-    self.node_groups = None
-
-  def sync_with_mode (self, mode = 'both'):
-    modes = {'both': {'blocks': True, 'mempool': True},
-             'blocks': {'blocks': True, 'mempool': False},
-             'mempool': {'blocks': False, 'mempool': True}}
-    assert mode in modes
-
-    node_groups = self.node_groups
-    if not node_groups:
-        node_groups = [self.nodes]
-
-    if modes[mode]['blocks']:
-        [sync_blocks(group) for group in node_groups]
-    if modes[mode]['mempool']:
-        [sync_mempools(group) for group in node_groups]
 
   def firstupdateName (self, ind, name, newData, value,
                        opt = None, allowActive = False):
@@ -79,19 +39,6 @@ class NameTestFramework (BitcoinTestFramework):
     if opt is None:
       return node.name_firstupdate (name, newData[1], newData[0], value)
     return node.name_firstupdate (name, newData[1], newData[0], value, opt)
-
-  def generate (self, ind, blocks, syncBefore = True):
-    """
-    Generate blocks and sync all nodes.
-    """
-
-    # Sync before to get the mempools up-to-date and sync afterwards
-    # to ensure that all blocks have propagated.
-
-    if syncBefore:
-        self.sync_with_mode ('both')
-    self.nodes[ind].generate (blocks)
-    self.sync_with_mode ('blocks')
 
   def checkName (self, ind, name, value, expiresIn, expired):
     """


### PR DESCRIPTION
This set of commits streamlines the Namecoin regtests, mostly the old ones that have been around for a couple of years without significant refactoring.  In particular, we now use the `invalidateblock` and `reconsiderblock` RPCs to test reorgs, rather than using separate nodes and splitting / joining the network (which used to be the only way to do those tests back in the day).

Also, in general we reduce the number of test nodes as much as possible, and avoid syncing between them where it is not necessary.  These syncs are the main cause of slowness in the Namecoin regtests.

This speeds up the tests massively, and at the same time makes them easier to read/understand, because the reader no longer needs to mentally keep track of so many different nodes and their states/roles.