### PR TITLE
Implement name lookups by hash

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -1,5 +1,13 @@
 # Release Notes for Namecoin
 
+## Version 0.21
+
+- By enabling `-namehashindex`, Namecoin Core can now keep track of a separate
+  database that maps hashes to preimages for all registered names.  With this,
+  `name_show` and `name_history` can now optionally look up names by hash.
+  This has uses for light clients, as discussed in
+  [#329](https://github.com/namecoin/namecoin-core/issues/329).
+
 ## Version 0.19
 
 - The mempool now allows multiple updates of a single name (in a chain of

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,6 +136,7 @@ BITCOIN_CORE_H = \
   httpserver.h \
   index/base.h \
   index/blockfilterindex.h \
+  index/namehash.h \
   index/txindex.h \
   indirectmap.h \
   init.h \
@@ -290,6 +291,7 @@ libbitcoin_server_a_SOURCES = \
   httpserver.cpp \
   index/base.cpp \
   index/blockfilterindex.cpp \
+  index/namehash.cpp \
   index/txindex.cpp \
   interfaces/chain.cpp \
   interfaces/node.cpp \

--- a/src/index/namehash.cpp
+++ b/src/index/namehash.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <index/namehash.h>
+
+#include <hash.h>
+#include <script/names.h>
+
+#include <utility>
+#include <vector>
+
+/** Database "key prefix" for the actual hash entries.  */
+constexpr char DB_HASH = 'h';
+
+class NameHashIndex::DB : public BaseIndex::DB
+{
+
+public:
+
+  explicit DB (const size_t cache_size, const bool memory, const bool wipe)
+    : BaseIndex::DB (GetDataDir () / "indexes" / "namehash",
+                     cache_size, memory, wipe)
+  {}
+
+  bool
+  ReadPreimage (const uint256& hash, valtype& name) const
+  {
+    return Read (std::make_pair (DB_HASH, hash), name);
+  }
+
+  bool WritePreimages (const std::vector<std::pair<uint256, valtype>>& data);
+
+};
+
+bool
+NameHashIndex::DB::WritePreimages (
+    const std::vector<std::pair<uint256, valtype>>& data)
+{
+  CDBBatch batch(*this);
+  for (const auto& entry : data)
+    batch.Write (std::make_pair (DB_HASH, entry.first), entry.second);
+
+  return WriteBatch (batch);
+}
+
+NameHashIndex::NameHashIndex (const size_t cache_size, const bool memory,
+                              const bool wipe)
+  : db(MakeUnique<NameHashIndex::DB> (cache_size, memory, wipe))
+{}
+
+NameHashIndex::~NameHashIndex () = default;
+
+bool
+NameHashIndex::WriteBlock (const CBlock& block, const CBlockIndex* pindex)
+{
+  std::vector<std::pair<uint256, valtype>> data;
+  for (const auto& tx : block.vtx)
+    for (const auto& out : tx->vout)
+      {
+        const CNameScript nameOp(out.scriptPubKey);
+        if (!nameOp.isNameOp () || nameOp.getNameOp () != OP_NAME_FIRSTUPDATE)
+          continue;
+
+        const valtype& name = nameOp.getOpName ();
+        const uint256 hash = Hash (name.begin (), name.end ());
+        data.emplace_back (hash, name);
+      }
+
+  return db->WritePreimages (data);
+}
+
+BaseIndex::DB&
+NameHashIndex::GetDB () const
+{
+  return *db;
+}
+
+bool
+NameHashIndex::FindNamePreimage (const uint256& hash, valtype& name) const
+{
+  return db->ReadPreimage (hash, name);
+}
+
+std::unique_ptr<NameHashIndex> g_name_hash_index;

--- a/src/index/namehash.h
+++ b/src/index/namehash.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2020 Daniel Kraft
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_NAMEHASH_H
+#define BITCOIN_INDEX_NAMEHASH_H
+
+#include <index/base.h>
+#include <script/script.h>
+#include <uint256.h>
+
+#include <memory>
+
+/** Default value for the -namehashindex argument.  */
+static constexpr bool DEFAULT_NAMEHASHINDEX = false;
+
+/** Maximum size of the DB cache for the name-hash index.  */
+static constexpr int64_t MAX_NAMEHASH_CACHE = 1024;
+
+/**
+ * This keeps an index of SHA-256d hashes of names to the corresponding preimage
+ * (the names themselves).  This allows "unhashing" known names, so that we
+ * can implement lookup of names in name_show and other commands by hash.
+ *
+ * What this enables is querying an untrusted node about the existence of
+ * a name, without the node learning what the name is if it does not exist yet.
+ *
+ * Note that this is "append only".  When rewinding a block that first
+ * mentions a name, we do not attempt to remove that name again from the index.
+ * There's not really a point in doing so.
+ */
+class NameHashIndex : public BaseIndex
+{
+
+private:
+
+  class DB;
+
+  const std::unique_ptr<DB> db;
+
+protected:
+
+    bool WriteBlock (const CBlock& block, const CBlockIndex* pindex) override;
+
+    BaseIndex::DB& GetDB () const override;
+
+    const char*
+    GetName () const override
+    {
+      return "namehash";
+    }
+
+public:
+
+    /**
+     * Constructs the index, which becomes available to be queried.
+     */
+    explicit NameHashIndex (size_t cache_size, bool memory, bool wipe);
+
+    ~NameHashIndex ();
+
+    /**
+     * Looks up a name by hash.  Returns false if the preimage cannot
+     * be found (because the name has not been indexed yet).
+     */
+    bool FindNamePreimage (const uint256& hash, valtype& name) const;
+
+};
+
+/** The global name-hash index.  May be null.  */
+extern std::unique_ptr<NameHashIndex> g_name_hash_index;
+
+#endif // BITCOIN_INDEX_NAMEHASH_H

--- a/src/rpc/names.h
+++ b/src/rpc/names.h
@@ -112,6 +112,7 @@ public:
 
   NameOptionsHelp& withNameEncoding ();
   NameOptionsHelp& withValueEncoding ();
+  NameOptionsHelp& withByHash ();
 
   /**
    * Variant of withField that also adds the innerArgs field correctly.

--- a/test/functional/name_byhash.py
+++ b/test/functional/name_byhash.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for lookups of names by hash rather than preimage.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+import hashlib
+
+
+class NameByHashTest (NameTestFramework):
+
+  def set_test_params (self):
+    # We start without -namehashindex initially so that we can test the
+    # "not enabled" error first.
+    self.setup_name_test ([["-namehistory"]] * 1)
+    self.setup_clean_chain = True
+
+  def run_test (self):
+    node = self.nodes[0]
+    node.generate (200)
+
+    name = "testname"
+    nameHex = name.encode ("ascii").hex ()
+    singleHash = hashlib.new ("sha256", name.encode ("ascii")).digest ()
+    doubleHashHex = hashlib.new ("sha256", singleHash).hexdigest ()
+    byHashOptions = {"nameEncoding": "hex", "byHash": "sha256d"}
+
+    # Start by setting up a test name.
+    new = node.name_new (name)
+    node.generate (10)
+    self.firstupdateName (0, name, new, "value")
+    node.generate (5)
+
+    # Check looking up "direct".
+    res = node.name_show (name, {"byHash": "direct"})
+    assert_equal (res["name"], name)
+    assert_equal (res["value"], "value")
+
+    # -namehashindex is not enabled yet.
+    assert_raises_rpc_error (-1, 'namehashindex is not enabled',
+                             node.name_show, doubleHashHex, byHashOptions)
+
+    # Restart the node and enable indexing.
+    self.restart_node (0, extra_args=["-namehashindex", "-namehistory"])
+
+    # Now the lookup by hash should work.
+    res = node.name_show (doubleHashHex, byHashOptions)
+    assert_equal (res["name"], nameHex)
+    assert_equal (res["value"], "value")
+    res = node.name_history (doubleHashHex, byHashOptions)
+    assert_equal (len (res), 1)
+    assert_equal (res[0]["name"], nameHex)
+
+    # Unknown name by hash.
+    assert_raises_rpc_error (-4, "name hash not found",
+                             node.name_show, "42" * 32, byHashOptions)
+
+    # General errors with the parameters.
+    assert_raises_rpc_error (-8, "Invalid value for byHash",
+                             node.name_show, doubleHashHex, {"byHash": "foo"})
+    assert_raises_rpc_error (-8, "must be 32 bytes long",
+                             node.name_show, "abcd", {"byHash": "sha256d"})
+
+
+if __name__ == '__main__':
+  NameByHashTest ().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -255,6 +255,7 @@ BASE_SCRIPTS = [
 
     # name tests
     'name_ant_workflow.py',
+    'name_byhash.py',
     'name_encodings.py',
     'name_expiration.py',
     'name_immature_inputs.py',


### PR DESCRIPTION
This set of changes implements https://github.com/namecoin/namecoin-core/issues/329:  A new option `-namehashindex` allows running Namecoin Core in a way that keeps an additional database of name hashes to preimages for all registered names.  When this is enabled, the new `byHash` option can be passed to `name_show` and `name_history` to request name lookup by hash rather than direct.

This is useful because it allows using an external node to check if a given name is registered or not, without revealing the name itself if it does not exist yet.  This may be useful for Electrum (and perhaps other light clients) in the future.