### PR TITLE
rpc: Make name_show RPC command error for expired names

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -2,6 +2,12 @@
 
 ## Version 0.21
 
+- `name_show` now (by default) shows an error for expired names. This can be
+  overridden by setting the `allowExpired` RPC option to true, or by using the
+  `-allowexpired` command-line parameter.
+  For more context,
+  see [issue #194](https://github.com/namecoin/namecoin-core/issues/194).
+
 - By enabling `-namehashindex`, Namecoin Core can now keep track of a separate
   database that maps hashes to preimages for all registered names.  With this,
   `name_show` and `name_history` can now optionally look up names by hash.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,6 +40,7 @@
 #include <policy/policy.h>
 #include <policy/settings.h>
 #include <rpc/blockchain.h>
+#include <rpc/names.h>
 #include <rpc/register.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
@@ -581,6 +582,7 @@ void SetupServerArgs(NodeContext& node)
     gArgs.AddArg("-nameencoding=<enc>", strprintf("Sets the default encoding used for names in the RPC interface (default: %s)", EncodingToString(DEFAULT_NAME_ENCODING)), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-valueencoding=<enc>", strprintf("Sets the default encoding used for values in the RPC interface (default: %s)", EncodingToString(DEFAULT_VALUE_ENCODING)), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-limitnamechains=<n>", strprintf("Limit pending chains of name operations for name_update to <n> (default: %u)", DEFAULT_NAME_CHAIN_LIMIT), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-allowexpired", strprintf("Throw error on expired names (default: %u)", DEFAULT_ALLOWEXPIRED), ArgsManager::ALLOW_BOOL, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2014-2020 Daniel Kraft
+// Copyright (c) 2020 yanmaani
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -437,7 +437,7 @@ namespace
 UniValue
 name_show (const JSONRPCRequest& request)
 {
-  bool allow_expired_default = DEFAULT_ALLOWEXPIRED;
+  const bool allow_expired_default = gArgs.GetBoolArg("-allowexpired", DEFAULT_ALLOWEXPIRED);
 
   NameOptionsHelp optHelp;
   optHelp

--- a/src/rpc/names.h
+++ b/src/rpc/names.h
@@ -13,6 +13,9 @@
 #include <string>
 #include <vector>
 
+/** Default value for the -allowexpired argument.  */
+static constexpr bool DEFAULT_ALLOWEXPIRED = true;
+
 class CNameData;
 class COutPoint;
 class CScript;

--- a/src/rpc/names.h
+++ b/src/rpc/names.h
@@ -14,7 +14,7 @@
 #include <vector>
 
 /** Default value for the -allowexpired argument.  */
-static constexpr bool DEFAULT_ALLOWEXPIRED = true;
+static constexpr bool DEFAULT_ALLOWEXPIRED = false;
 
 class CNameData;
 class COutPoint;

--- a/test/functional/name_allowexpired.py
+++ b/test/functional/name_allowexpired.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Licensed under CC0 (Public domain)
+
+# Test that name_show displays expired names if allow_expired = true,
+# and otherwise throws "not found" errors (if allow_expired = false).
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameExpirationTest(NameTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_name_test([
+            ["-allowexpired"],
+            ["-noallowexpired"]
+        ])
+
+    def run_test(self):
+        idx_allow = 0
+        idx_disallow = 1
+        node = self.nodes[idx_allow]
+        node_disallow = self.nodes[idx_disallow]
+        node.generate(200)
+
+        self.log.info("Begin registration of two names.")
+        # "d/active" and (2) "d/expired".
+        # "d/active" will be renewed.
+        # "d/expired" will be let to lapse.
+        #
+        # To look up "d/expired" should either succeed or throw an error,
+        # depending on the values of (1) the JSON option allowExpired
+        # and (2) the command-line parameter -allowexpired.
+        # Looking up "d/active" should always succeed regardless.
+        new_active = node.name_new("d/active")
+        new_expired = node.name_new("d/expired")
+        node.generate(12)
+
+        self.log.info("Register the names.")
+        self.firstupdateName(0, "d/active", new_active, "value")
+        self.firstupdateName(0, "d/expired", new_expired, "value")
+        node.generate(1)
+        # names on regtest expire after 30 blocks
+        self.log.info("Wait 1 block, make sure domains registered.")
+        self.checkName(0, "d/active", "value", 30, False)
+        self.checkName(0, "d/expired", "value", 30, False)
+        
+        self.log.info("Let half a registration interval pass.")
+        node.generate(15)
+        
+        self.log.info("Renew d/active.")
+        node.name_update("d/active", "renewed")
+        # Don't renew d/expired. 
+        self.log.info("Let d/expired lapse.")
+        node.generate(16)
+        # 30 - 15 = 15
+
+        self.log.info("Check default behaviors.")
+        self.sync_blocks(self.nodes)
+        self.checkName(idx_allow, "d/expired", "value", -1, True)
+        assert_raises_rpc_error(-4, 'name not found',
+            node_disallow.name_show, "d/expired")
+
+        self.log.info("Check positive JSON overrides.")
+        # checkName only accepts one parameter, use checkNameData
+        self.checkNameData(
+            node.name_show("d/expired", {"allowExpired": True}),
+            "d/expired", "value", -1, True)
+        self.checkNameData(
+            node_disallow.name_show("d/expired", {"allowExpired": True}),
+            "d/expired", "value", -1, True)
+
+        self.log.info("Check negative JSON overrides.")
+        assert_raises_rpc_error(-4, 'name not found',
+            node.name_show, "d/expired", {"allowExpired": False})
+        assert_raises_rpc_error(-4, 'name not found',
+            node_disallow.name_show, "d/expired", {"allowExpired": False})
+
+if __name__ == '__main__':
+    NameExpirationTest ().main ()

--- a/test/functional/name_expiration.py
+++ b/test/functional/name_expiration.py
@@ -13,7 +13,7 @@ class NameExpirationTest (NameTestFramework):
 
   def set_test_params (self):
     self.setup_clean_chain = True
-    self.setup_name_test ([["-namehistory"]])
+    self.setup_name_test ([["-namehistory", "-allowexpired"]])
 
   def checkUTXO (self, name, shouldBeThere):
     """

--- a/test/functional/name_listunspent.py
+++ b/test/functional/name_listunspent.py
@@ -11,7 +11,7 @@ from test_framework.util import *
 class NameListUnspentTest (NameTestFramework):
 
   def set_test_params (self):
-    self.setup_name_test ([[]] * 2)
+    self.setup_name_test ([["-allowexpired"]] * 2)
 
   def lookupName (self, ind, name, **kwargs):
     """Wrapper around lookup that gets txid and vout from the name."""

--- a/test/functional/name_registration.py
+++ b/test/functional/name_registration.py
@@ -13,7 +13,7 @@ class NameRegistrationTest (NameTestFramework):
 
   def set_test_params (self):
     self.setup_clean_chain = True
-    self.setup_name_test ([["-namehistory"], []])
+    self.setup_name_test ([["-namehistory", "-allowexpired"], []])
 
   def generateToOther (self, n):
     """

--- a/test/functional/name_utxo.py
+++ b/test/functional/name_utxo.py
@@ -12,7 +12,7 @@ from test_framework.util import *
 class NameUtxoTest (NameTestFramework):
 
   def set_test_params (self):
-    self.setup_name_test ([[]] * 1)
+    self.setup_name_test ([["-allowexpired"]] * 1)
 
   def run_test (self):
     node = self.nodes[0]

--- a/test/functional/name_wallet.py
+++ b/test/functional/name_wallet.py
@@ -22,7 +22,7 @@ class NameWalletTest (NameTestFramework):
 
   def set_test_params (self):
     self.setup_clean_chain = True
-    self.setup_name_test ([["-paytxfee=%s" % txFee]] * 2)
+    self.setup_name_test ([["-paytxfee=%s" % txFee, "-allowexpired"]] * 2)
 
   def generateToOther (self, ind, n):
     """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -261,6 +261,7 @@ BASE_SCRIPTS = [
     'auxpow_zerohash.py',
 
     # name tests
+    'name_allowexpired.py',
     'name_ant_workflow.py',
     'name_byhash.py',
     'name_encodings.py',


### PR DESCRIPTION
This set of changes makes `name_show` throw an error for expired names. This behavior can be overridden by setting the `allowExpired` RPC option to true, or by using the `-allowexpired` command-line parameter.

This behavior is discussed in issue #194.