### PR TITLE
Add namepsbt RPC method

### DIFF
--- a/doc/release-notes-namecoin.md
+++ b/doc/release-notes-namecoin.md
@@ -8,6 +8,10 @@
   This has uses for light clients, as discussed in
   [#329](https://github.com/namecoin/namecoin-core/issues/329).
 
+- The new RPC method `namepsbt` can be used to generate name operations
+  based on PSBTs.  It works in the same way as the existing
+  `namerawtransaction`.
+
 ## Version 0.19
 
 - The mempool now allows multiple updates of a single name (in a chain of

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -11,6 +11,7 @@
 #include <names/common.h>
 #include <names/main.h>
 #include <primitives/transaction.h>
+#include <psbt.h>
 #include <rpc/blockchain.h>
 #include <rpc/names.h>
 #include <rpc/server.h>
@@ -799,6 +800,115 @@ name_pending (const JSONRPCRequest& request)
 
 /* ************************************************************************** */
 
+namespace
+{
+
+/**
+ * Performs the action of namerawtransaction and namepsbt on a given
+ * CMutableTransaction.  This is used to share the code between the two
+ * RPC methods.
+ *
+ * If a name_new is created and a rand value chosen, it will be placed
+ * into the JSON output "result" already.
+ */
+void
+PerformNameRawtx (const int nOut, const UniValue& nameOp,
+                  CMutableTransaction& mtx, UniValue& result)
+{
+  mtx.SetNamecoin ();
+
+  if (nOut < 0 || nOut >= mtx.vout.size ())
+    throw JSONRPCError (RPC_INVALID_PARAMETER, "vout is out of range");
+  auto& script = mtx.vout[nOut].scriptPubKey;
+
+  RPCTypeCheckObj (nameOp,
+    {
+      {"op", UniValueType (UniValue::VSTR)},
+    }
+  );
+  const std::string op = find_value (nameOp, "op").get_str ();
+
+  /* namerawtransaction does not have an options argument.  This would just
+     make the already long list of arguments longer.  Instead of using
+     namerawtransaction, namecoin-tx can be used anyway to create name
+     operations with arbitrary hex data.  */
+  const UniValue NO_OPTIONS(UniValue::VOBJ);
+
+  if (op == "name_new")
+    {
+      RPCTypeCheckObj (nameOp,
+        {
+          {"name", UniValueType (UniValue::VSTR)},
+          {"rand", UniValueType (UniValue::VSTR)},
+        },
+        true);
+
+      valtype rand;
+      if (nameOp.exists ("rand"))
+        {
+          const std::string randStr = find_value (nameOp, "rand").get_str ();
+          if (!IsHex (randStr))
+            throw JSONRPCError (RPC_DESERIALIZATION_ERROR, "rand must be hex");
+          rand = ParseHex (randStr);
+        }
+      else
+        {
+          rand.resize (20);
+          GetRandBytes (&rand[0], rand.size ());
+        }
+
+      const valtype name
+          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
+
+      script = CNameScript::buildNameNew (script, name, rand);
+      result.pushKV ("rand", HexStr (rand));
+    }
+  else if (op == "name_firstupdate")
+    {
+      RPCTypeCheckObj (nameOp,
+        {
+          {"name", UniValueType (UniValue::VSTR)},
+          {"value", UniValueType (UniValue::VSTR)},
+          {"rand", UniValueType (UniValue::VSTR)},
+        }
+      );
+
+      const std::string randStr = find_value (nameOp, "rand").get_str ();
+      if (!IsHex (randStr))
+        throw JSONRPCError (RPC_DESERIALIZATION_ERROR, "rand must be hex");
+      const valtype rand = ParseHex (randStr);
+
+      const valtype name
+          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
+      const valtype value
+          = DecodeValueFromRPCOrThrow (find_value (nameOp, "value"),
+                                       NO_OPTIONS);
+
+      script = CNameScript::buildNameFirstupdate (script, name, value, rand);
+    }
+  else if (op == "name_update")
+    {
+      RPCTypeCheckObj (nameOp,
+        {
+          {"name", UniValueType (UniValue::VSTR)},
+          {"value", UniValueType (UniValue::VSTR)},
+        }
+      );
+
+      const valtype name
+          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
+      const valtype value
+          = DecodeValueFromRPCOrThrow (find_value (nameOp, "value"),
+                                       NO_OPTIONS);
+
+      script = CNameScript::buildNameUpdate (script, name, value);
+    }
+  else
+    throw JSONRPCError (RPC_INVALID_PARAMETER, "Invalid name operation");
+}
+
+} // anonymous namespace
+
 UniValue
 namerawtransaction (const JSONRPCRequest& request)
 {
@@ -837,106 +947,67 @@ namerawtransaction (const JSONRPCRequest& request)
   CMutableTransaction mtx;
   if (!DecodeHexTx (mtx, request.params[0].get_str (), true))
     throw JSONRPCError (RPC_DESERIALIZATION_ERROR, "TX decode failed");
-  mtx.SetNamecoin ();
-
-  const size_t nOut = request.params[1].get_int ();
-  if (nOut >= mtx.vout.size ())
-    throw JSONRPCError (RPC_INVALID_PARAMETER, "vout is out of range");
-
-  const UniValue nameOp = request.params[2].get_obj ();
-  RPCTypeCheckObj (nameOp,
-    {
-      {"op", UniValueType (UniValue::VSTR)},
-    }
-  );
-  const std::string op = find_value (nameOp, "op").get_str ();
-
-  /* namerawtransaction does not have an options argument.  This would just
-     make the already long list of arguments longer.  Instead of using
-     namerawtransaction, namecoin-tx can be used anyway to create name
-     operations with arbitrary hex data.  */
-  const UniValue NO_OPTIONS(UniValue::VOBJ);
 
   UniValue result(UniValue::VOBJ);
 
-  if (op == "name_new")
-    {
-      RPCTypeCheckObj (nameOp,
-        {
-          {"name", UniValueType (UniValue::VSTR)},
-          {"rand", UniValueType (UniValue::VSTR)},
-        },
-        true);
-
-      valtype rand;
-      if (nameOp.exists ("rand"))
-        {
-          const std::string randStr = find_value (nameOp, "rand").get_str ();
-          if (!IsHex (randStr))
-            throw JSONRPCError (RPC_DESERIALIZATION_ERROR, "rand must be hex");
-          rand = ParseHex (randStr);
-        }
-      else
-        {
-          rand.resize (20);
-          GetRandBytes (&rand[0], rand.size ());
-        }
-
-      const valtype name
-          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
-
-      mtx.vout[nOut].scriptPubKey
-        = CNameScript::buildNameNew (mtx.vout[nOut].scriptPubKey, name, rand);
-      result.pushKV ("rand", HexStr (rand));
-    }
-  else if (op == "name_firstupdate")
-    {
-      RPCTypeCheckObj (nameOp,
-        {
-          {"name", UniValueType (UniValue::VSTR)},
-          {"value", UniValueType (UniValue::VSTR)},
-          {"rand", UniValueType (UniValue::VSTR)},
-        }
-      );
-
-      const std::string randStr = find_value (nameOp, "rand").get_str ();
-      if (!IsHex (randStr))
-        throw JSONRPCError (RPC_DESERIALIZATION_ERROR, "rand must be hex");
-      const valtype rand = ParseHex (randStr);
-
-      const valtype name
-          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
-      const valtype value
-          = DecodeValueFromRPCOrThrow (find_value (nameOp, "value"),
-                                       NO_OPTIONS);
-
-      mtx.vout[nOut].scriptPubKey
-        = CNameScript::buildNameFirstupdate (mtx.vout[nOut].scriptPubKey,
-                                             name, value, rand);
-    }
-  else if (op == "name_update")
-    {
-      RPCTypeCheckObj (nameOp,
-        {
-          {"name", UniValueType (UniValue::VSTR)},
-          {"value", UniValueType (UniValue::VSTR)},
-        }
-      );
-
-      const valtype name
-          = DecodeNameFromRPCOrThrow (find_value (nameOp, "name"), NO_OPTIONS);
-      const valtype value
-          = DecodeValueFromRPCOrThrow (find_value (nameOp, "value"),
-                                       NO_OPTIONS);
-
-      mtx.vout[nOut].scriptPubKey
-        = CNameScript::buildNameUpdate (mtx.vout[nOut].scriptPubKey,
-                                        name, value);
-    }
-  else
-    throw JSONRPCError (RPC_INVALID_PARAMETER, "Invalid name operation");
+  PerformNameRawtx (request.params[1].get_int (), request.params[2].get_obj (),
+                    mtx, result);
 
   result.pushKV ("hex", EncodeHexTx (CTransaction (mtx)));
+  return result;
+}
+
+UniValue
+namepsbt (const JSONRPCRequest& request)
+{
+  RPCHelpMan ("namepsbt",
+      "\nAdds a name operation to an existing PSBT.\n"
+      "\nUse createpsbt first to create the basic transaction, including the required inputs and outputs also for the name.\n",
+      {
+          {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "A base64 string of a PSBT"},
+          {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The vout of the desired name output"},
+          {"nameop", RPCArg::Type::OBJ, RPCArg::Optional::NO, "The name operation to create",
+              {
+                  {"op", RPCArg::Type::STR, RPCArg::Optional::NO, "The operation to perform, can be \"name_new\", \"name_firstupdate\" and \"name_update\""},
+                  {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name to operate on"},
+                  {"value", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The new value for the name"},
+                  {"rand", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The nonce value to use for registrations"},
+              },
+           "nameop"},
+      },
+      RPCResult {RPCResult::Type::OBJ, "", "",
+          {
+              {RPCResult::Type::STR_HEX, "psbt", "The serialised, updated PSBT"},
+              {RPCResult::Type::STR_HEX, "rand", /* optional */ true, "If this is a name_new, the nonce used to create it"},
+          },
+      },
+      RPCExamples {
+          HelpExampleCli ("namepsbt", R"("psbt" 1 "{\"op\":\"name_new\",\"name\":\"my-name\")")
+        + HelpExampleCli ("namepsbt", R"("psbt" 1 "{\"op\":\"name_firstupdate\",\"name\":\"my-name\",\"value\":\"new value\",\"rand\":\"00112233\")")
+        + HelpExampleCli ("namepsbt", R"("psbt" 1 "{\"op\":\"name_update\",\"name\":\"my-name\",\"value\":\"new value\")")
+        + HelpExampleRpc ("namepsbt", R"("psbt", 1, "{\"op\":\"name_update\",\"name\":\"my-name\",\"value\":\"new value\")")
+      }
+  ).Check (request);
+
+  RPCTypeCheck (request.params,
+                {UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ});
+
+  PartiallySignedTransaction psbtx;
+  std::string error;
+  if (!DecodeBase64PSBT (psbtx, request.params[0].get_str (), error))
+    throw JSONRPCError (RPC_DESERIALIZATION_ERROR,
+                        strprintf ("TX decode failed %s", error));
+
+  UniValue result(UniValue::VOBJ);
+
+  PerformNameRawtx (request.params[1].get_int (), request.params[2].get_obj (),
+                    *psbtx.tx, result);
+
+  CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+  ssTx << psbtx;
+  const auto* data = reinterpret_cast<const unsigned char*> (ssTx.data ());
+  result.pushKV ("psbt", EncodeBase64 (data, ssTx.size ()));
+
   return result;
 }
 
@@ -971,12 +1042,13 @@ void RegisterNameRPCCommands(CRPCTable &t)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
-    { "names",              "name_show",              &name_show,              {"name","options"} },
-    { "names",              "name_history",           &name_history,           {"name","options"} },
-    { "names",              "name_scan",              &name_scan,              {"start","count","options"} },
-    { "names",              "name_pending",           &name_pending,           {"name","options"} },
+    { "names",              "name_show",              &name_show,              {"name", "options"} },
+    { "names",              "name_history",           &name_history,           {"name", "options"} },
+    { "names",              "name_scan",              &name_scan,              {"start", "count", "options"} },
+    { "names",              "name_pending",           &name_pending,           {"name", "options"} },
     { "names",              "name_checkdb",           &name_checkdb,           {} },
-    { "rawtransactions",    "namerawtransaction",     &namerawtransaction,     {"hexstring","vout","nameop"} },
+    { "rawtransactions",    "namerawtransaction",     &namerawtransaction,     {"hexstring", "vout", "nameop"} },
+    { "rawtransactions",    "namepsbt",               &namepsbt,               {"psbt", "vout", "nameop"} },
 };
 
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)

--- a/test/functional/name_ant_workflow.py
+++ b/test/functional/name_ant_workflow.py
@@ -53,14 +53,14 @@ class NameAntWorkflowTest (NameTestFramework):
       for vout in data["vout"]:
         fullOuts.append ({vout["scriptPubKey"]["addresses"][0]: vout["value"]})
     combined = self.nodes[1].createrawtransaction (fullIns, fullOuts)
+    combined = self.nodes[1].converttopsbt (combined)
 
     nameOp = {
       "op": "name_update",
       "name": "x/name",
       "value": "updated",
     }
-    combined = self.nodes[1].namerawtransaction (combined, 0, nameOp)["hex"]
-    combined = self.nodes[1].converttopsbt (combined)
+    combined = self.nodes[1].namepsbt (combined, 0, nameOp)["psbt"]
 
     # Sign and broadcast the partial tx.
     sign1 = self.nodes[0].walletprocesspsbt (combined)

--- a/test/functional/name_psbt.py
+++ b/test/functional/name_psbt.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Daniel Kraft
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC tests for name operations with PSBTs.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+from decimal import Decimal
+
+class NamePsbtTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 2)
+
+  def run_test (self):
+
+    # Go through the full name "life cycle" (name_new, name_firstupdate and
+    # name_update) with the PSBT interface.
+    newOp = {"op": "name_new", "name": "d/my-name"}
+    newAddr = self.nodes[0].getnewaddress ()
+    newOutp, newData = self.rawNameOp (0, None, newAddr, newOp)
+    self.nodes[0].generate (10)
+
+    firstOp = {"op": "name_firstupdate", "rand": newData["rand"],
+               "name": "d/my-name", "value": "first value"}
+    firstAddr = self.nodes[0].getnewaddress ()
+    firstOutp, firstData = self.rawNameOp (0, newOutp, firstAddr, firstOp)
+    self.nodes[0].generate (5)
+    self.checkName (0, "d/my-name", "first value", None, False)
+
+    updOp = {"op": "name_update", "name": "d/my-name", "value": "new value"}
+    updAddr = self.nodes[0].getnewaddress ()
+    _, updData = self.rawNameOp (0, firstOutp, updAddr, updOp)
+    self.nodes[0].generate (1)
+    self.checkName (0, "d/my-name", "new value", None, False)
+
+    # Decode the name_new.
+    data = self.decodePsbt (self.nodes[0], newData["psbt"])
+    assert_equal (data["op"], "name_new")
+    assert "hash" in data
+
+    # Decode name_firstupdate.
+    data = self.decodePsbt (self.nodes[0], firstData["psbt"])
+    assert_equal (data["op"], "name_firstupdate")
+    assert_equal (data["name"], "d/my-name")
+    assert_equal (data["value"], "first value")
+    assert_equal (data["rand"], newData["rand"])
+
+    # Decode name_update.
+    data = self.decodePsbt (self.nodes[0], updData["psbt"])
+    assert_equal (data["op"], "name_update")
+    assert_equal (data["name"], "d/my-name")
+    assert_equal (data["value"], "new value")
+
+    # Verify range check of vout in namepsbt.
+    tx = self.nodes[0].createpsbt ([], {})
+    assert_raises_rpc_error (-8, "vout is out of range",
+                             self.nodes[0].namepsbt, tx, 0, {})
+    assert_raises_rpc_error (-8, "vout is out of range",
+                             self.nodes[0].namepsbt, tx, -1, {})
+
+  def decodePsbt (self, node, psbt):
+    """
+    Decodes a PSBT and finds the output that is a name operation.  Returns
+    the decoded nameop entry.
+    """
+
+    data = node.decodepsbt (psbt)["tx"]
+
+    res = None
+    for out in data["vout"]:
+      if "nameOp" in out["scriptPubKey"]:
+        assert_equal (res, None)
+        res = out["scriptPubKey"]["nameOp"]
+
+        # Extra check:  Verify that the address is decoded correctly.
+        addr = out["scriptPubKey"]["addresses"]
+        assert_equal (out["scriptPubKey"]["type"], "pubkeyhash")
+        assert_equal (len (addr), 1)
+        validation = node.validateaddress (addr[0])
+        assert_equal (validation["isvalid"], True)
+
+    assert res is not None
+    return res
+
+  def rawNameOp (self, ind, nameIn, toAddr, op):
+    """
+    Utility method to construct and send a name-operation transaction with
+    the PSBT interface.  It uses the provided input (if not None)
+    for the name and finds other inputs to fund the tx.  It sends the name
+    to toAddr with the operation defined by op.
+    """
+
+    fee = Decimal ("0.001")
+    nameAmount = Decimal ("0.01")
+
+    node = self.nodes[ind]
+    changeAddr = node.getrawchangeaddress ()
+
+    vin = []
+    vout = []
+    for u in node.listunspent ():
+      if u["amount"] > fee + nameAmount:
+        vin.append (u)
+        vout.append ({changeAddr: u["amount"] - fee - nameAmount})
+        break
+
+    assert len (vin) > 0, "found no suitable funding input"
+
+    if nameIn is not None:
+      vin.append (nameIn)
+    nameInd = len (vout)
+    vout.append ({toAddr: nameAmount})
+
+    tx = node.createpsbt (vin, vout)
+    nameTx = node.namepsbt (tx, nameInd, op)
+
+    tx = node.walletprocesspsbt (nameTx["psbt"])
+    assert_equal (tx["complete"], True)
+    tx = node.finalizepsbt (tx["psbt"])
+    txid = node.sendrawtransaction (tx["hex"])
+
+    return {"txid": txid, "vout": nameInd}, nameTx
+
+
+if __name__ == '__main__':
+  NamePsbtTest ().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -274,6 +274,7 @@ BASE_SCRIPTS = [
     'name_multisig.py --bip16-active',
     'name_multiupdate.py',
     'name_pending.py',
+    'name_psbt.py',
     'name_rawtx.py',
     'name_registration.py',
     'name_reorg.py',


### PR DESCRIPTION
This adds a new RPC method, `namepsbt`.  It works in the same way as `namerawtransaction` to add a name operation to an existing output, but operates on PSBTs rather than hex-format raw transactions.  This fixes #361.

With this, it is possible to go through the entire name-trading workflow with just PSBTs and without any hex-format raw transactions.  However, it is not yet possible to let the wallet fund the transaction, as that requires funding without the out-of-wallet name input first and only later adding it to the PSBT.  Once https://github.com/bitcoin/bitcoin/issues/19608 is implemented, this will be possible as well.