### PR TITLE
Make name value optional in name_firstupdate and name_update

### DIFF
--- a/test/functional/name_novalue.py
+++ b/test/functional/name_novalue.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Licensed under CC0 (Public domain)
+
+# Test that name_firstupdate and name_update handle missing
+# name values gracefully. This test uses direct RPC calls.
+# Testing the wrappers is out of scope.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameNovalueTest(NameTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.setup_name_test ([["-namehistory", "-limitnamechains=3"]])
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.generate(200)
+
+        new_name = node.name_new("d/name")
+        node.generate(12)
+        self.log.info("Began registration of name.")
+
+        # use node.name_firstupdate - we're not testing the framework
+        node.name_firstupdate ("d/name", new_name[1], new_name[0])
+        node.generate(1)
+        self.log.info("Name registered; no value provided.")
+
+        self.checkName(0, "d/name", "", 30, False)
+        self.log.info("Value equals empty string.")
+
+        node.name_update("d/name", "1")
+        node.generate(1)
+        self.log.info('Value changed to "1"; change is in chain.')
+
+        self.checkName(0, "d/name", "1", 30, False)
+        self.log.info('Value equals "1".')
+
+        node.name_update("d/name")
+        node.generate(1)
+        self.log.info("Updated; no value specified.")
+
+        self.checkName(0, "d/name", "1", 30, False)
+        self.log.info('Name was updated. Value still equals "1".')
+
+        node.name_update("d/name", "2")
+        node.name_update("d/name")
+        node.name_update("d/name", "3")
+        node.generate(1)
+        self.log.info('Stack of 3 registrations performed.')
+
+        history = node.name_history("d/name")
+        reference = ["", "1", "1", "2", "2", "3"]
+        assert(list(map(lambda x: x['value'], history)) == reference)
+        self.log.info('Updates correctly consider updates in the mempool.')
+
+
+if __name__ == '__main__':
+    NameNovalueTest ().main ()

--- a/test/functional/test_framework/names.py
+++ b/test/functional/test_framework/names.py
@@ -21,7 +21,7 @@ class NameTestFramework (BitcoinTestFramework):
     # test_framework.py.  This is needed to get us out of IBD.
     self.mocktime = 1388534400 + (201 * 10 * 60)
 
-  def firstupdateName (self, ind, name, newData, value,
+  def firstupdateName (self, ind, name, newData, value = None,
                        opt = None, allowActive = False):
     """
     Utility routine to perform a name_firstupdate command.  The rand
@@ -36,9 +36,11 @@ class NameTestFramework (BitcoinTestFramework):
       return node.name_firstupdate (name, newData[1], newData[0],
                                     value, opt, True)
 
-    if opt is None:
+    if opt is not None:
+      return node.name_firstupdate (name, newData[1], newData[0], value, opt)
+    if value is not None:
       return node.name_firstupdate (name, newData[1], newData[0], value)
-    return node.name_firstupdate (name, newData[1], newData[0], value, opt)
+    return node.name_firstupdate (name, newData[1], newData[0])
 
   def checkName (self, ind, name, value, expiresIn, expired):
     """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -281,6 +281,7 @@ BASE_SCRIPTS = [
     'name_multisig.py',
     'name_multisig.py --bip16-active',
     'name_multiupdate.py',
+    'name_novalue.py',
     'name_pending.py',
     'name_psbt.py',
     'name_rawtx.py',


### PR DESCRIPTION
This patch amends `name_firstupdate` and `name_update` to make the `value` parameter optional. As proposed in #372, a missing value in `name_firstupdate` equals the empty string, and a missing value in `name_update` equals the last value of the name.

It also amends the test suite to support writing tests that do not furnish name values. That change is intended to make it easier to write future tests; it isn't relied upon by the test of the implemented feature, which uses direct RPC calls.

Fixes #372.