### PR TITLE
Fix some auxpow CI errors

### DIFF
--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -76,6 +76,12 @@ public:
 
   CAuxPow () = default;
 
+  CAuxPow (CAuxPow&&) = default;
+  CAuxPow& operator= (CAuxPow&&) = default;
+
+  CAuxPow (const CAuxPow&) = delete;
+  void operator= (const CAuxPow&) = delete;
+
   SERIALIZE_METHODS (CAuxPow, obj)
   {
     /* The coinbase Merkle tx' hashBlock field is never actually verified

--- a/src/rpc/auxpow_miner.h
+++ b/src/rpc/auxpow_miner.h
@@ -61,13 +61,15 @@ private:
    * fills in the difficulty target value.
    */
   const CBlock* getCurrentBlock (const CTxMemPool& mempool,
-                                 const CScript& scriptPubKey, uint256& target);
+                                 const CScript& scriptPubKey, uint256& target)
+      EXCLUSIVE_LOCKS_REQUIRED (cs);
 
   /**
    * Looks up a previously constructed block by its (hex-encoded) hash.  If the
    * block is found, it is returned.  Otherwise, a JSONRPCError is thrown.
    */
-  const CBlock* lookupSavedBlock (const std::string& hashHex) const;
+  const CBlock* lookupSavedBlock (const std::string& hashHex) const
+      EXCLUSIVE_LOCKS_REQUIRED (cs);
 
   friend class auxpow_tests::AuxpowMinerForTest;
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -569,7 +569,7 @@ BOOST_FIXTURE_TEST_CASE (auxpow_miner_blockRegeneration, TestChain100Setup)
   CMutableTransaction mtx;
   mtx.vout.emplace_back (1234, scriptPubKey);
   {
-    LOCK (mempool.cs);
+    LOCK2 (cs_main, mempool.cs);
     mempool.addUnchecked (entry.FromTx (mtx));
   }
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -202,7 +202,7 @@ CAuxpowBuilder::get (const CTransactionRef tx) const
   res.nChainIndex = auxpowChainIndex;
   res.parentBlock = parentBlock;
 
-  return res;
+  return std::move (res);
 }
 
 valtype


### PR DESCRIPTION
This fixes some small oversights in the `auxpow` code that fail compilation with `clang` due to static analysis or other warnings, as pointed out by Cirrus CI.

Fixes #388.