### PR TITLE
Fix Gitian path for depends

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -57,7 +57,7 @@ def build():
 
     subprocess.check_call(['wget', '-O', 'inputs/osslsigncode-2.0.tar.gz', 'https://github.com/mtrojnar/osslsigncode/archive/2.0.tar.gz'])
     subprocess.check_call(["echo '5a60e0a4b3e0b4d655317b2f12a810211c50242138322b16e7e01c6fbb89d92f inputs/osslsigncode-2.0.tar.gz' | sha256sum -c"], shell=True)
-    subprocess.check_call(['make', '-C', '../namecoin/depends', 'download', 'SOURCES_PATH=' + os.getcwd() + '/cache/common'])
+    subprocess.check_call(['make', '-C', '../namecoin-core/depends', 'download', 'SOURCES_PATH=' + os.getcwd() + '/cache/common'])
 
     if args.linux:
         print('\nCompiling ' + args.version + ' Linux')


### PR DESCRIPTION
This PR fixes a bug where `gitian-build.py --build` would result in the error `../namecoin/depends: No such file or directory`.

This will also need to be backported to the `0.21` branch (I expect it to cherry-pick cleanly).