### PR TITLE
Rebrand Gitian distname

### DIFF
--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -9,4 +9,4 @@ if RECENT_TAG="$(git describe --exact-match HEAD)"; then
 else
     VERSION="$(git rev-parse --short=12 HEAD)"
 fi
-DISTNAME="bitcoin-${VERSION}"
+DISTNAME="namecoin-${VERSION}"


### PR DESCRIPTION
This PR fixes a bug where `gitian-build.py --build` would result in the error `mv: cannot stat 'build/out/namecoin-*.tar.gz': No such file or directory`.

This will also need to be backported to the `0.21` branch (I expect it to cherry-pick cleanly).