### PR TITLE
Rebrand macOS deploy readme

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -6,7 +6,7 @@ The `macdeployqtplus` script should not be run manually. Instead, after building
 make deploy
 ```
 
-When complete, it will have produced `Bitcoin-Core.dmg`.
+When complete, it will have produced `Namecoin-Core.dmg`.
 
 ## SDK Extraction
 


### PR DESCRIPTION
This will also need to be backported to the `0.21` branch, but it will probably not cherry-pick cleanly, so I'll send a separate PR for the backport once this is merged.