### PR TITLE
Rebrand macOS deploy readme (0.21 backport)

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -10,7 +10,7 @@ During the deployment process, the disk image window will pop up briefly
 when the fancy settings are applied. This is normal, please do not interfere,
 the process will unmount the DMG and cleanup before finishing.
 
-When complete, it will have produced `Bitcoin-Qt.dmg`.
+When complete, it will have produced `Namecoin-Qt.dmg`.
 
 ## SDK Extraction
 


### PR DESCRIPTION
Backport of https://github.com/namecoin/namecoin-core/pull/402 to `0.21`.