### PR TITLE
Deterministic salts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -286,6 +286,7 @@ BITCOIN_CORE_H = \
   wallet/ismine.h \
   wallet/load.h \
   wallet/rpcwallet.h \
+  wallet/rpcnames.h \
   wallet/salvage.h \
   wallet/scriptpubkeyman.h \
   wallet/sqlite.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -160,6 +160,7 @@ BITCOIN_TESTS += \
   wallet/test/coinselector_tests.cpp \
   wallet/test/init_tests.cpp \
   wallet/test/ismine_tests.cpp \
+  wallet/test/rpcnames_tests.cpp \
   wallet/test/scriptpubkeyman_tests.cpp
 
 FUZZ_SUITE_LD_COMMON +=\

--- a/src/wallet/rpcnames.h
+++ b/src/wallet/rpcnames.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 yanmaani
+// Licensed under CC0 (Public domain)
+
+#ifndef BITCOIN_WALLET_RPCNAMES_H
+#define BITCOIN_WALLET_RPCNAMES_H
+
+bool getNameSalt(const CKey& key, const valtype& name, valtype& rand);
+
+#endif //BITCOIN_WALLET_RPCNAMES_H

--- a/src/wallet/test/rpcnames_tests.cpp
+++ b/src/wallet/test/rpcnames_tests.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 yanmaani
+// Licensed under CC0 (Public domain)
+
+#include <test/util/setup_common.h>
+#include <key_io.h>
+#include <wallet/rpcnames.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(rpcnames_tests, RegTestingSetup) // Keys are in regtest format
+
+static void
+TestNameSalt(const std::string& privkey_b58, const std::string& name_str, const std::string& expectedSalt_hex) {
+    const CKey privkey = DecodeSecret(privkey_b58);
+    const valtype name(name_str.begin(), name_str.end());
+    const valtype expectedSalt = ParseHex(expectedSalt_hex);
+
+    valtype salt(20);
+    getNameSalt(privkey, name, salt);
+
+    BOOST_CHECK(salt == expectedSalt);
+}
+
+BOOST_AUTO_TEST_CASE(name_salts)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    TestNameSalt( // test_name_salt_addr_p2pkh
+                /* private key   */ "cQDxbmQfwRV3vP1mdnVHq37nJekHLsuD3wdSQseBRA2ct4MFk5Pq",
+                /* name          */ "d/wikileaks",
+                /* expected salt */ "c33f6d84c93d769da2a8882ed9d4a69e2052dd9a");
+    TestNameSalt( // test_name_salt_addr_p2wpkh_p2sh
+                /* private key   */ "cU9hVzhpvfn91u2zTVn8uqF2ymS7ucYH8V5TmsTDmuyMHgRk9WsJ",
+                /* name          */ "d/wikileaks",
+                /* expected salt */ "b14763659b268460865db01b2b10b80a9cbe9ceb");
+    TestNameSalt( // test_name_salt_addr_p2wpkh
+                /* private key   */ "cPuQzcNEgbeYZ5at9VdGkCwkPA9r34gvEVJjuoz384rTfYpahfe7",
+                /* name          */ "d/wikileaks",
+                /* expected salt */ "a39038cddfcc17d391b8620639a72178dc73b19a");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/name_deterministic_salt.py
+++ b/test/functional/name_deterministic_salt.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Licensed under CC0 (Public domain)
+
+# Test that name_new and name_firstupdate use deterministic salts.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameDeterministicSaltTest(NameTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.setup_name_test ([[]])
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.sethdseed(seed="cQDxbmQfwRV3vP1mdnVHq37nJekHLsuD3wdSQseBRA2ct4MFk5Pq")
+        assert(node.listwallets() != [])
+
+        node.generate(200)
+
+        self.log.info("Begin registration of name.")
+        new_name = node.name_new('d/wikileaks')
+
+        self.log.info("Make sure salt matches.")
+        assert_equal(new_name[1], '40d0f82281da919314fbb3331d4c43f5005ecc0e')
+
+        node.generate(12)
+        self.log.info("Leave both fields blank (null).")
+        node.name_firstupdate ("d/wikileaks")
+        node.generate(1)
+        self.checkName(0, "d/wikileaks", "", 30, False)
+        self.log.info("Name registered; no value provided.")
+
+        self.log.info("Now let's register a name and give it the TXID, but leave it to figure out the rand value.")
+
+        new_name = node.name_new('d/name2')
+        node.generate(12)
+        node.name_firstupdate ("d/name2", None, new_name[0])
+        node.generate(1)
+        self.checkName(0, "d/name2", "", 30, False)
+
+        self.log.info("Now let's register a name and give it the rand value, but leave it to figure out the txid.")
+
+        new_name = node.name_new('d/name3')
+        node.generate(12)
+        node.name_firstupdate ("d/name3", new_name[1])
+        node.generate(1)
+        self.checkName(0, "d/name3", "", 30, False)
+
+        self.log.info("Neither gave any exceptions.")
+
+        self.log.info("Now let's register a name and give it a wrong (but existing) TXID.")
+
+        new_name1 = node.name_new('d/name4')
+        new_name2 = node.name_new('d/dummy')
+        node.generate(12)
+        assert_raises_rpc_error(-25, "generated rand for txid does not match", node.name_firstupdate, "d/name4", None, new_name2[0])
+
+        self.log.info("Gave exception, as expected.")
+
+
+if __name__ == '__main__':
+    NameDeterministicSaltTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -308,6 +308,7 @@ BASE_SCRIPTS = [
     'name_allowexpired.py',
     'name_ant_workflow.py',
     'name_byhash.py',
+    'name_deterministic_salt.py',
     'name_encodings.py',
     'name_expiration.py',
     'name_immature_inputs.py',


### PR DESCRIPTION
This patch amends `name_new` and `name_firstupdate` to, respectively, register new names with deterministically generated salts, and to try using such salt as `rand` value if no salt is provided.

If it is not possible to generate such salt, e.g. because the private key for the address to which the name is sent is not available, it will fall back to generating a random salt.

Closes #368.