### PR TITLE
Transaction queue

### DIFF
--- a/src/wallet/rpcnames.cpp
+++ b/src/wallet/rpcnames.cpp
@@ -905,6 +905,43 @@ queuerawtransaction ()
 /* ************************************************************************** */
 
 RPCHelpMan
+dequeuetransaction ()
+{
+  return RPCHelpMan ("dequeuetransaction",
+      "\nRemove a transaction from the queue.",
+      {
+          {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction ID of the transaction to be dequeued"},
+      },
+      RPCResult {RPCResult::Type::NONE, "", ""},
+      RPCExamples {
+          HelpExampleCli("dequeuetransaction", "txid") +
+          HelpExampleRpc("dequeuetransaction", "txid")
+      },
+      [&] (const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+  std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest (request);
+  if (!wallet) return NullUniValue;
+
+  RPCTypeCheck (request.params,
+                {UniValue::VSTR});
+
+  const uint256& txid = ParseHashV (request.params[0], "txid");
+
+  LOCK (wallet->cs_wallet);
+
+  if (!wallet->EraseQueuedTransaction(txid))
+  {
+    throw JSONRPCError (RPC_WALLET_ERROR, "Error dequeueing transaction");
+  }
+
+  return NullUniValue;
+}
+  );
+}
+
+/* ************************************************************************** */
+
+RPCHelpMan
 listqueuedtransactions ()
 {
   return RPCHelpMan{"listqueuedtransactions",

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4825,6 +4825,8 @@ extern RPCHelpMan name_list(); // in rpcnames.cpp
 extern RPCHelpMan name_new();
 extern RPCHelpMan name_firstupdate();
 extern RPCHelpMan name_update();
+extern RPCHelpMan queuerawtransaction();
+extern RPCHelpMan listqueuedtransactions();
 extern RPCHelpMan sendtoname();
 
 Span<const CRPCCommand> GetWalletRPCCommands()
@@ -4906,6 +4908,8 @@ static const CRPCCommand commands[] =
     { "names",              &name_new,                       },
     { "names",              &name_firstupdate,               },
     { "names",              &name_update,                    },
+    { "names",              &queuerawtransaction             },
+    { "names",              &listqueuedtransactions,         },
     { "names",              &sendtoname,                     },
 };
 // clang-format on

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4826,6 +4826,7 @@ extern RPCHelpMan name_new();
 extern RPCHelpMan name_firstupdate();
 extern RPCHelpMan name_update();
 extern RPCHelpMan queuerawtransaction();
+extern RPCHelpMan dequeuetransaction();
 extern RPCHelpMan listqueuedtransactions();
 extern RPCHelpMan sendtoname();
 
@@ -4909,6 +4910,7 @@ static const CRPCCommand commands[] =
     { "names",              &name_firstupdate,               },
     { "names",              &name_update,                    },
     { "names",              &queuerawtransaction             },
+    { "names",              &dequeuetransaction              },
     { "names",              &listqueuedtransactions,         },
     { "names",              &sendtoname,                     },
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1252,6 +1252,7 @@ void CWallet::blockConnected(const CBlock& block, int height)
         SyncTransaction(block.vtx[index], {CWalletTx::Status::CONFIRMED, height, block_hash, (int)index});
         transactionRemovedFromMempool(block.vtx[index], MemPoolRemovalReason::BLOCK, 0 /* mempool_sequence */);
     }
+    EffectTransactionQueue();
 }
 
 void CWallet::blockDisconnected(const CBlock& block, int height)
@@ -4374,6 +4375,36 @@ bool CWallet::GetQueuedTransaction(const uint256 &txid, CMutableTransaction *dat
     if (data != nullptr)
         (*data) = it->second;
     return true;
+}
+
+void CWallet::EffectTransactionQueue()
+{
+    // This is called when we get a new block to deal with queued transactions.
+    if (chain().isInitialBlockDownload())
+        return;
+    // We only do this for fresh blocks. Otherwise, we might trigger way too early.
+    std::set<uint256> to_dequeue;
+    // Kludge; we can't remove items in a map while iterating over it.
+    AssertLockHeld(cs_wallet);
+    for (const auto& i : queuedTransactionMap)
+    // For each transaction in the queue...
+    {
+        const uint256& txid = i.first;
+        const CMutableTransaction& tx = i.second;
+
+        std::string unused_err_string;
+        if (chain().broadcastTransaction(MakeTransactionRef(tx), m_default_max_tx_fee, /* relay */ true, unused_err_string))
+        // attempt to broadcast
+        {
+            to_dequeue.emplace(txid);
+            WalletLogPrintf("Broadcast queued transaction with txid %s, %s", txid.GetHex(), CTransaction(tx).ToString().c_str());
+            // No newline here, since tx's ToString contains one.
+        }
+        // If the transaction isn't yet valid, there's nothing to do.
+    }
+
+    for (const auto& i : to_dequeue)
+        queuedTransactionMap.erase(i);
 }
 
 CKeyPool::CKeyPool()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -9,6 +9,7 @@
 #include <amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <names/common.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <psbt.h>
@@ -1352,6 +1353,15 @@ public:
 
     //! Add a descriptor to the wallet, return a ScriptPubKeyMan & associated output type
     ScriptPubKeyMan* AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label, bool internal);
+
+    std::map<uint256, CMutableTransaction> queuedTransactionMap;
+
+    bool QueuedTransactionExists(const uint256 &txid) const;
+    bool WriteQueuedTransaction(
+            const uint256 &txid,
+            const CMutableTransaction &tx);
+    bool EraseQueuedTransaction(const uint256 &txid);
+    bool GetQueuedTransaction(const uint256 &txid, CMutableTransaction *data=nullptr) const;
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -769,6 +769,8 @@ private:
      */
     static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, bilingual_str& error, std::vector<bilingual_str>& warnings);
 
+    void EffectTransactionQueue();
+
 public:
     /**
      * Main wallet lock.

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <amount.h>
+#include <names/common.h>
 #include <script/sign.h>
 #include <wallet/db.h>
 #include <wallet/walletutil.h>
@@ -253,6 +254,9 @@ public:
     bool EraseDestData(const std::string &address, const std::string &key);
 
     bool WriteActiveScriptPubKeyMan(uint8_t type, const uint256& id, bool internal);
+
+    bool WriteQueuedTransaction(const uint256& txid, const CMutableTransaction& tx);
+    bool EraseQueuedTransaction(const uint256& txid);
 
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWalletTx>& vWtx);

--- a/test/functional/name_txnqueue.py
+++ b/test/functional/name_txnqueue.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Licensed under CC0 (Public domain)
+
+# Test that transaction queue works.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameTransactionQueueTest(NameTestFramework):
+    def set_test_params(self):
+        self.setup_name_test ([[]] * 1)
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0] # alias
+        node.generate(200) # get out of IBD
+
+        self.log.info("Begin registering a name.")
+        # cribbed from name_immature_inputs.py by Daniel Kraft
+        addr = node.getnewaddress()
+        new = node.name_new("d/name", {"destAddress": addr})
+        newTx = node.getrawtransaction(new[0])
+        nameInd = self.rawtxOutputIndex(0, newTx, addr)
+
+        self.log.info("Mine that transaction.")
+        node.generate(1)
+
+        self.log.info("Create a NAME_FIRSTUPDATE with sequence=12...")
+        nameAmount = Decimal('0.01')
+        ins        = [{"txid": new[0], "vout": nameInd, "sequence": 13}] # 12 blocks
+        txRaw      = node.createrawtransaction(ins, {addr: nameAmount})
+        op         = {"op": "name_firstupdate", "name": "d/name",
+                      "value": "value", "rand": new[1]}
+        txName     = node.namerawtransaction(txRaw, 0, op)['hex']
+        txFunded   = node.fundrawtransaction(txName)['hex']
+        signed     = node.signrawtransactionwithwallet(txFunded)
+        assert signed['complete']
+        signedHex  = signed['hex']
+
+        self.log.info("Enqueue it.")
+        txid = node.queuerawtransaction(signedHex)
+
+        self.log.info("Make sure it's there.")
+        assert txid in node.listqueuedtransactions()
+
+        self.log.info("Take it out.")
+        node.dequeuetransaction(txid)
+
+        self.log.info("Make sure it's gone.")
+        assert txid not in node.listqueuedtransactions()
+
+        self.log.info("Put it back in again.")
+        txid = node.queuerawtransaction(signedHex)
+        assert txid in node.listqueuedtransactions()
+
+        self.log.info("Wait 11 blocks...")
+        node.generate(11)
+
+        self.log.info("Make sure it hasn't been broadcast yet.")
+        assert txid in node.listqueuedtransactions()
+
+        self.log.info("Wait one block more.")
+        node.generate(1)
+
+        self.log.info("Make sure it's been dequeued.")
+        assert txid not in node.listqueuedtransactions()
+
+        self.log.info("Wait one block for the transaction to be confirmed.")
+        node.generate(1)
+
+        self.log.info("Check name is registered.")
+        self.checkName(0, "d/name", "value", 30, False)
+
+        self.log.info("OK!")
+
+        self.log.info("Queue some garbage.")
+        # this parses, but is not valid
+        assert_raises_rpc_error(-4, "Invalid transaction (bad-txns-vin-empty)", node.queuerawtransaction, "01000000000000000000")
+
+        self.log.info("Make a valid transaction, check it's instantly broadcast.")
+        dummy_addr     = node.getnewaddress()
+        dummy_txRaw    = node.createrawtransaction([], {dummy_addr: Decimal("1")})
+        dummy_txFunded = node.fundrawtransaction(dummy_txRaw)['hex']
+        dummy_txSigned = node.signrawtransactionwithwallet(dummy_txFunded)['hex']
+
+        self.log.info("Put it in.")
+        dummy_txid = node.queuerawtransaction(dummy_txSigned)
+        self.log.info("Make sure it's already gone.")
+        assert dummy_txid not in node.listqueuedtransactions()
+        self.log.info("Make sure it's in the mempool.")
+        assert dummy_txid in node.getrawmempool()
+
+if __name__ == '__main__':
+    NameTransactionQueueTest ().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -332,6 +332,8 @@ BASE_SCRIPTS = [
     'name_segwit.py',
     'name_segwit.py --descriptors',
     'name_sendcoins.py',
+    'name_txnqueue.py --legacy-wallet',
+    'name_txnqueue.py --descriptors',
     'name_utxo.py',
     'name_wallet.py',
     'name_wallet.py --descriptors',


### PR DESCRIPTION
This patch adds a transaction queue to Namecoin, building off Jeremy Rand and Brandon Roberts' work (#266). Unfortunately, it is not yet ready for merge, since there is a bug in `listqueuedtransactions`.

I'm also unsure, should changelogs for this (and #422) go under 0.21 or 0.21.1?

Notes:
* New RPC `queuerawtransaction`
* New RPC `dequeuetransaction`
* New RPC `listqueuedtransactions`
* API has been simplified; caller is expected to use nSequence in queued transaction. Triggers have been removed.
* When a block is received, the transaction queue will be processed. This is done in `CWallet::blockConnected` to have access to the chain; it's a bit unseemly but I don't see a cleaner way to do it.
* **`listqueuedtransactions` hangs about 20% of the time trying to acquire a lock; the offending line is `LOCK2 (cs_main, pwallet->cs_wallet);`. I have no idea why it does this or how to debug it. It seems to be totally random; sometimes the functional test triggers it and sometimes it doesn't.**