### PR TITLE
(WIP) Add name_autoregister RPC

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4820,6 +4820,7 @@ RPCHelpMan importdescriptors();
 RPCHelpMan listdescriptors();
 
 extern RPCHelpMan name_list(); // in rpcnames.cpp
+extern RPCHelpMan name_autoregister();
 extern RPCHelpMan name_new();
 extern RPCHelpMan name_firstupdate();
 extern RPCHelpMan name_update();
@@ -4904,6 +4905,7 @@ static const CRPCCommand commands[] =
 
     // Name-related wallet calls.
     { "names",              &name_list,                      },
+    { "names",              &name_autoregister,              },
     { "names",              &name_new,                       },
     { "names",              &name_firstupdate,               },
     { "names",              &name_update,                    },

--- a/test/functional/name_autoregister.py
+++ b/test/functional/name_autoregister.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Licensed under CC0 (Public domain)
+
+# Test that name_autoregister works
+
+from test_framework.names import NameTestFramework
+from test_framework.util import *
+
+class NameAutoregisterTest(NameTestFramework):
+
+    def set_test_params(self):
+        self.setup_name_test ([[]] * 1)
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0] # alias
+        node.generate(200) # get out of IBD
+
+        self.log.info("Register a name.")
+        node.name_autoregister("d/name", "value")
+        node.generate(1)
+        assert(len(node.listqueuedtransactions()) == 1)
+        self.log.info("Queue contains 1 transaction.")
+        self.log.info("Wait 12 blocks.")
+        node.generate(12)
+        assert(len(node.listqueuedtransactions()) == 0)
+        self.log.info("Queue is empty.")
+        self.log.info("Wait 1 more block so transaction can get mined.")
+        node.generate(1)
+        self.checkNameData(node.name_show("d/name"), "d/name", "value", 30, False)
+        self.log.info("Name is registered.")
+
+        self.log.info("Check delegation: normal case.")
+        node.name_autoregister("d/delegated", "value", {"delegate": True})
+        assert(len(node.listqueuedtransactions()) == 2)
+        node.generate(14)
+        assert(len(node.listqueuedtransactions()) == 0)
+        self.checkNameData(node.name_show("d/delegated"), "d/delegated", '{"import":"dd/delegated"}', 30, False)
+        self.checkNameData(node.name_show("dd/delegated"), "dd/delegated", 'value', 30, False)
+
+        self.log.info("Check delegation: appending digits.")
+        node.name_autoregister("dd/delegated2", "value")
+        node.generate(14)
+        node.name_autoregister("d/delegated2", "value", {"delegate": True})
+        node.generate(14)
+        self.log.info("Value is: " + node.name_show("d/delegated2")['value'])
+        assert(node.name_show("d/delegated2")['value'] != '{"import":"dd/delegated2"}')
+
+if __name__ == '__main__':
+    NameAutoregisterTest ().main ()


### PR DESCRIPTION
Adds a `name_autoregister` RPC call.

This isn't ready for merge, because I can't figure out how to make it mark the inputs as unspendable, which means it will exhibit undesirable behavior with delegated names. I tried `CommitTransaction` and a few other things, and I still couldn't seem to make it work. (Would be grateful if @domob1812 could bail me out here)

There is also a minor refactor in `name_new`. It may be prudent to do a deeper refactor of all the name transactions, to separate the "create transaction" and "broadcast transaction" fully, like in Electrum(-NMC).

The test does not pass because of the issue I described.