### PR TITLE
Add name_firstupdate GUI

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -31,6 +31,7 @@ QT_FORMS_UI = \
   qt/forms/debugwindow.ui \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
+  qt/forms/buynamespage.ui \
   qt/forms/managenamespage.ui \
   qt/forms/configurenamedialog.ui \
   qt/forms/signverifymessagedialog.ui \
@@ -47,6 +48,7 @@ QT_MOC_CPP = \
   qt/moc_bitcoinamountfield.cpp \
   qt/moc_bitcoingui.cpp \
   qt/moc_bitcoinunits.cpp \
+  qt/moc_buynamespage.cpp \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
@@ -120,6 +122,7 @@ BITCOIN_QT_H = \
   qt/bitcoinamountfield.h \
   qt/bitcoingui.h \
   qt/bitcoinunits.h \
+  qt/buynamespage.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
@@ -260,6 +263,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/addressbookpage.cpp \
   qt/addresstablemodel.cpp \
   qt/askpassphrasedialog.cpp \
+  qt/buynamespage.cpp \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
   qt/configurenamedialog.cpp \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -5,6 +5,7 @@
 #include <qt/bitcoingui.h>
 
 #include <qt/bitcoinunits.h>
+#include <qt/buynamespage.h>
 #include <qt/clientmodel.h>
 #include <qt/createwalletdialog.h>
 #include <qt/guiconstants.h>
@@ -282,11 +283,22 @@ void BitcoinGUI::createActions()
     historyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_4));
     tabGroup->addAction(historyAction);
 
+    buyNamesAction = new QAction(platformStyle->SingleColorIcon(":/icons/bitcoin_transparent_letter"), tr("&Buy Names"), this);
+    buyNamesAction->setStatusTip(tr("Register new names"));
+    buyNamesAction->setToolTip(buyNamesAction->statusTip());
+    buyNamesAction->setCheckable(true);
+    buyNamesAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
+    tabGroup->addAction(buyNamesAction);
+
+    buyNamesMenuAction = new QAction(buyNamesAction->text(), this);
+    buyNamesMenuAction->setStatusTip(buyNamesAction->statusTip());
+    buyNamesMenuAction->setToolTip(buyNamesMenuAction->statusTip());
+
     manageNamesAction = new QAction(platformStyle->SingleColorIcon(":/icons/bitcoin_transparent_letter"), tr("&Manage Names"), this);
     manageNamesAction->setStatusTip(tr("Manage registered names"));
     manageNamesAction->setToolTip(manageNamesAction->statusTip());
     manageNamesAction->setCheckable(true);
-    manageNamesAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
+    manageNamesAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_6));
     tabGroup->addAction(manageNamesAction);
 
     manageNamesMenuAction = new QAction(manageNamesAction->text(), this);
@@ -308,6 +320,8 @@ void BitcoinGUI::createActions()
     connect(receiveCoinsMenuAction, &QAction::triggered, this, &BitcoinGUI::gotoReceiveCoinsPage);
     connect(historyAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
     connect(historyAction, &QAction::triggered, this, &BitcoinGUI::gotoHistoryPage);
+    connect(buyNamesAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(buyNamesAction, &QAction::triggered, this, &BitcoinGUI::gotoBuyNamesPage);
     connect(manageNamesAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
     connect(manageNamesAction, &QAction::triggered, this, &BitcoinGUI::gotoManageNamesPage);
 #endif // ENABLE_WALLET
@@ -567,6 +581,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
+        toolbar->addAction(buyNamesAction);
         toolbar->addAction(manageNamesAction);
         overviewAction->setChecked(true);
 
@@ -773,6 +788,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
     historyAction->setEnabled(enabled);
+    buyNamesAction->setEnabled(enabled);
     manageNamesAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
@@ -824,6 +840,7 @@ void BitcoinGUI::createTrayIconMenu()
     if (enableWallet) {
         trayIconMenu->addAction(sendCoinsMenuAction);
         trayIconMenu->addAction(receiveCoinsMenuAction);
+        trayIconMenu->addAction(buyNamesMenuAction);
         trayIconMenu->addAction(manageNamesMenuAction);
         trayIconMenu->addSeparator();
         trayIconMenu->addAction(signMessageAction);
@@ -918,6 +935,12 @@ void BitcoinGUI::gotoSendCoinsPage(QString addr)
 {
     sendCoinsAction->setChecked(true);
     if (walletFrame) walletFrame->gotoSendCoinsPage(addr);
+}
+
+void BitcoinGUI::gotoBuyNamesPage()
+{
+    buyNamesAction->setChecked(true);
+    if (walletFrame) walletFrame->gotoBuyNamesPage();
 }
 
 void BitcoinGUI::gotoManageNamesPage()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -140,6 +140,8 @@ private:
     QAction* sendCoinsMenuAction = nullptr;
     QAction* usedSendingAddressesAction = nullptr;
     QAction* usedReceivingAddressesAction = nullptr;
+    QAction* buyNamesAction = nullptr;
+    QAction* buyNamesMenuAction = nullptr;
     QAction* manageNamesAction = nullptr;
     QAction* manageNamesMenuAction = nullptr;
     QAction* signMessageAction = nullptr;
@@ -282,6 +284,8 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to buy names page */
+    void gotoBuyNamesPage();
     /** Switch to manage names page */
     void gotoManageNamesPage();
 

--- a/src/qt/buynamespage.cpp
+++ b/src/qt/buynamespage.cpp
@@ -1,0 +1,114 @@
+#include <qt/buynamespage.h>
+#include <qt/forms/ui_buynamespage.h>
+
+#include <interfaces/node.h>
+#include <qt/configurenamedialog.h>
+#include <qt/guiutil.h>
+#include <qt/platformstyle.h>
+#include <qt/walletmodel.h>
+
+#include <QMessageBox>
+
+#include <optional>
+
+BuyNamesPage::BuyNamesPage(const PlatformStyle *platformStyle, QWidget *parent) :
+    QWidget(parent),
+    platformStyle(platformStyle),
+    ui(new Ui::BuyNamesPage),
+    walletModel(nullptr)
+{
+    ui->setupUi(this);
+
+    connect(ui->registerNameButton, &QPushButton::clicked, this, &BuyNamesPage::onRegisterNameAction);
+
+    ui->registerName->installEventFilter(this);
+}
+
+BuyNamesPage::~BuyNamesPage()
+{
+    delete ui;
+}
+
+void BuyNamesPage::setModel(WalletModel *walletModel)
+{
+    this->walletModel = walletModel;
+}
+
+bool BuyNamesPage::eventFilter(QObject *object, QEvent *event)
+{
+    if (event->type() == QEvent::FocusIn)
+    {
+        if (object == ui->registerName)
+        {
+            ui->registerNameButton->setDefault(true);
+        }
+    }
+    return QWidget::eventFilter(object, event);
+}
+
+void BuyNamesPage::onRegisterNameAction()
+{
+    if (!walletModel)
+        return;
+
+    QString name = ui->registerName->text();
+
+    WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+    if (!ctx.isValid())
+        return;
+
+    ConfigureNameDialog dlg(platformStyle, name, "", this);
+    dlg.setModel(walletModel);
+
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    const QString &newValue = dlg.getReturnData();
+    const std::optional<QString> transferToAddress = dlg.getTransferTo();
+
+    const QString err_msg = this->firstupdate(name, newValue, transferToAddress);
+    if (!err_msg.isEmpty() && err_msg != "ABORTED")
+    {
+        QMessageBox::critical(this, tr("Name registration error"), err_msg);
+        return;
+    }
+
+    // reset UI text
+    ui->registerName->setText("d/");
+    ui->registerNameButton->setDefault(true);
+}
+
+QString BuyNamesPage::firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const
+{
+    std::string strName = name.toStdString();
+    LogPrintf ("wallet attempting name_firstupdate: name=%s\n", strName);
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV ("name", strName);
+
+    if (value)
+    {
+        params.pushKV ("value", value.value().toStdString());
+    }
+
+    if (transferTo)
+    {
+        UniValue options(UniValue::VOBJ);
+        options.pushKV ("destAddress", transferTo.value().toStdString());
+        params.pushKV ("options", options);
+    }
+
+    std::string walletURI = "/wallet/" + walletModel->getWalletName().toStdString();
+
+    UniValue res;
+    try {
+       res = walletModel->node().executeRpc("name_firstupdate", params, walletURI);
+    }
+    catch (const UniValue& e) {
+        UniValue message = find_value(e, "message");
+        std::string errorStr = message.get_str();
+        LogPrintf ("name_firstupdate error: %s\n", errorStr);
+        return QString::fromStdString(errorStr);
+    }
+    return tr ("");
+}

--- a/src/qt/buynamespage.h
+++ b/src/qt/buynamespage.h
@@ -1,0 +1,41 @@
+#ifndef BUYNAMESPAGE_H
+#define BUYNAMESPAGE_H
+
+#include <qt/platformstyle.h>
+
+#include <QWidget>
+
+class WalletModel;
+
+namespace Ui {
+    class BuyNamesPage;
+}
+
+QT_BEGIN_NAMESPACE
+QT_END_NAMESPACE
+
+/** Page for buying names */
+class BuyNamesPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit BuyNamesPage(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    ~BuyNamesPage();
+
+    void setModel(WalletModel *walletModel);
+
+private:
+    const PlatformStyle *platformStyle;
+    Ui::BuyNamesPage *ui;
+    WalletModel *walletModel;
+
+    QString firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
+
+private Q_SLOTS:
+    bool eventFilter(QObject *object, QEvent *event);
+
+    void onRegisterNameAction();
+};
+
+#endif // BUYNAMESPAGE_H

--- a/src/qt/forms/buynamespage.ui
+++ b/src/qt/forms/buynamespage.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BuyNamesPage</class>
+ <widget class="QWidget" name="BuyNamesPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>776</width>
+    <height>364</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QFrame" name="frame2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>&amp;New name:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>registerName</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QValidatedLineEdit" name="registerName">
+        <property name="toolTip">
+         <string>Enter a name to register it.</string>
+        </property>
+        <property name="text">
+         <string>d/</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Use &lt;strong&gt;d/&lt;/strong&gt; prefix for domain names. E.g. &lt;strong&gt;d/mysite&lt;/strong&gt; will register &lt;strong&gt;mysite.bit&lt;/strong&gt;&lt;br&gt;See &lt;a href=&quot;https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys&quot;&gt;Domain Names: Keys&lt;/a&gt; for reference. Other prefixes can be used for miscellaneous purposes (not domain names).&lt;/p&gt;</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::RichText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="registerNameButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Register the name.  You must have already pre-registered it.</string>
+        </property>
+        <property name="text">
+         <string>&amp;Register Name&#8230;</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qt/qvalidatedlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -174,6 +174,13 @@ void WalletFrame::gotoSendCoinsPage(QString addr)
         i.value()->gotoSendCoinsPage(addr);
 }
 
+void WalletFrame::gotoBuyNamesPage()
+{
+    QMap<WalletModel*, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoBuyNamesPage();
+}
+
 void WalletFrame::gotoManageNamesPage()
 {
     QMap<WalletModel*, WalletView*>::const_iterator i;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -74,6 +74,8 @@ public Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+    /** Switch to buy names page */
+    void gotoBuyNamesPage();
     /** Switch to manage names page */
     void gotoManageNamesPage();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -6,6 +6,7 @@
 
 #include <qt/addressbookpage.h>
 #include <qt/askpassphrasedialog.h>
+#include <qt/buynamespage.h>
 #include <qt/clientmodel.h>
 #include <qt/guiutil.h>
 #include <qt/managenamespage.h>
@@ -57,6 +58,7 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
 
     receiveCoinsPage = new ReceiveCoinsDialog(platformStyle);
     sendCoinsPage = new SendCoinsDialog(platformStyle);
+    buyNamesPage = new BuyNamesPage(platformStyle);
     manageNamesPage = new ManageNamesPage(platformStyle);
 
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
@@ -66,6 +68,7 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     addWidget(transactionsPage);
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
+    addWidget(buyNamesPage);
     addWidget(manageNamesPage);
 
     connect(overviewPage, &OverviewPage::transactionClicked, this, &WalletView::transactionClicked);
@@ -113,6 +116,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     sendCoinsPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
     usedSendingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
+    buyNamesPage->setModel(_walletModel);
     manageNamesPage->setModel(_walletModel);
 
     if (_walletModel)
@@ -179,6 +183,11 @@ void WalletView::gotoSendCoinsPage(QString addr)
 
     if (!addr.isEmpty())
         sendCoinsPage->setAddress(addr);
+}
+
+void WalletView::gotoBuyNamesPage()
+{
+    setCurrentWidget(buyNamesPage);
 }
 
 void WalletView::gotoManageNamesPage()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -15,6 +15,7 @@ class PlatformStyle;
 class ReceiveCoinsDialog;
 class SendCoinsDialog;
 class SendCoinsRecipient;
+class BuyNamesPage;
 class ManageNamesPage;
 class TransactionView;
 class WalletModel;
@@ -62,6 +63,7 @@ private:
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
+    BuyNamesPage *buyNamesPage;
     ManageNamesPage *manageNamesPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
@@ -85,6 +87,8 @@ public Q_SLOTS:
     void gotoSignMessageTab(QString addr = "");
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
+    /** Show Namecoin buy names page */
+    void gotoBuyNamesPage();
     /** Show Namecoin manage names page */
     void gotoManageNamesPage();
 


### PR DESCRIPTION
This PR adds a GUI for `name_firstupdate`, based on Brandon's port of Mikhail's GUI.  AFAICT, once https://github.com/namecoin/namecoin-core/pull/436 is merged, patching this GUI to use `name_autoregister` instead should be roughly a one-liner.  Until then, it's still a UX improvement over the status quo, even though the user needs to run `name_new` themselves.

Refs https://github.com/namecoin/namecoin-core/pull/187