### PR TITLE
Give more specific errors in name_show

### DIFF
--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -531,7 +531,7 @@ name_show ()
     if (!chainman.ActiveChainstate ().CoinsTip ().GetName (name, data))
       {
         std::ostringstream msg;
-        msg << "name not found: " << EncodeNameForMessage (name);
+        msg << "name never existed: " << EncodeNameForMessage (name);
         throw JSONRPCError (RPC_WALLET_ERROR, msg.str ());
       }
   }
@@ -544,7 +544,7 @@ name_show ()
   if (is_expired && !allow_expired)
     {
       std::ostringstream msg;
-      msg << "name not found: " << EncodeNameForMessage(name);
+      msg << "name expired: " << EncodeNameForMessage(name);
       throw JSONRPCError(RPC_WALLET_ERROR, msg.str());
     }
   return name_object;


### PR DESCRIPTION
More detail is always good UX-wise.  Doesn't change the error code, so this isn't an API-breaking change.