### PR TITLE
Show namespace in Type column of Transactions tab

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -168,6 +168,7 @@ BITCOIN_CORE_H = \
   mapport.h \
   memusage.h \
   merkleblock.h \
+  names/applications.h \
   names/common.h \
   names/encoding.h \
   names/main.h \
@@ -579,6 +580,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   key_io.cpp \
   merkleblock.cpp \
+  names/applications.cpp \
   names/common.cpp \
   names/encoding.cpp \
   net_types.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -104,6 +104,7 @@ BITCOIN_TESTS =\
   test/minisketch_tests.cpp \
   test/multisig_tests.cpp \
   test/name_tests.cpp \
+  test/name_applications_tests.cpp \
   test/name_mempool_tests.cpp \
   test/net_peer_eviction_tests.cpp \
   test/net_tests.cpp \

--- a/src/names/applications.cpp
+++ b/src/names/applications.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 Jeremy Rand
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <names/applications.h>
+
+#include <names/encoding.h>
+
+#include <regex>
+
+namespace
+{
+
+NameNamespace
+NamespaceFromString (const std::string& str)
+{
+    if (str == "d/")
+        return NameNamespace::Domain;
+    if (str == "dd/")
+        return NameNamespace::DomainData;
+    if (str == "id/")
+        return NameNamespace::Identity;
+    if (str == "idd/")
+        return NameNamespace::IdentityData;
+
+    return NameNamespace::NonStandard;
+}
+
+std::string
+NamespaceToString (NameNamespace ns)
+{
+    switch (ns)
+    {
+        case NameNamespace::Domain:
+            return "d/";
+        case NameNamespace::DomainData:
+            return "dd/";
+        case NameNamespace::Identity:
+            return "id/";
+        case NameNamespace::IdentityData:
+            return "idd/";
+        case NameNamespace::NonStandard:
+            return "";
+    }
+
+    /* NameNamespace values are only ever created internally in the binary
+    and not received externally (except as string).  Thus it should never
+    happen (and if it does, is a severe bug) that we see an unexpected
+    value.  */
+    assert (false);
+}
+
+NameNamespace
+PurportedNamespaceFromName (const std::string& name)
+{
+    const auto slashPos = name.find("/");
+    if (slashPos == std::string::npos)
+    {
+        return NameNamespace::NonStandard;
+    }
+
+    const std::string namespaceStr = name.substr(0, slashPos+1);
+    return NamespaceFromString(namespaceStr);
+}
+
+} // anonymous namespace
+
+NameNamespace
+NamespaceFromName (const std::string& name)
+{
+    const NameNamespace purported = PurportedNamespaceFromName(name);
+    const std::string purportedStr = NamespaceToString(purported);
+    const auto purportedLen = purportedStr.length();
+
+    const std::string label = name.substr(purportedLen);
+
+    if (label.empty())
+    {
+        return NameNamespace::NonStandard;
+    }
+
+    switch (purported)
+    {
+        case NameNamespace::Domain:
+        {
+            // Source: https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys
+            if (label.length() > 63)
+            {
+                return NameNamespace::NonStandard;
+            }
+
+            // Source: https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys
+            // The ^ and $ are omitted relative to the spec because
+            // std::regex_match implies them.
+            std::regex domainPattern("(xn--)?[a-z0-9]+(-[a-z0-9]+)*");
+            if (!std::regex_match (label, domainPattern))
+            {
+                return NameNamespace::NonStandard;
+            }
+
+            // Reject digits-only labels
+            // Source: https://github.com/namecoin/proposals/blob/master/ifa-0001.md#keys
+            std::regex digitsOnly("[0-9]+");
+            if (std::regex_match (label, digitsOnly))
+            {
+                return NameNamespace::NonStandard;
+            }
+
+            return NameNamespace::Domain;
+        }
+        case NameNamespace::Identity:
+        {
+            // Max id/ identifier length is 255 chars according to wiki spec.
+            // But we don't need to check for this, because that's also the max
+            // length of an identifier under the Namecoin consensus rules.
+
+            // Same as d/ regex but without IDN prefix.
+            // TODO: this doesn't exactly match the https://wiki.namecoin.org spec.
+            std::regex identityPattern("[a-z0-9]+(-[a-z0-9]+)*");
+            if (!std::regex_match (label, identityPattern))
+            {
+                return NameNamespace::NonStandard;
+            }
+
+            return NameNamespace::Identity;
+        }
+        case NameNamespace::DomainData:
+        case NameNamespace::IdentityData:
+        case NameNamespace::NonStandard:
+            return purported;
+    }
+
+    /* NameNamespace values are only ever created internally in the binary
+    and not received externally (except as string).  Thus it should never
+    happen (and if it does, is a severe bug) that we see an unexpected
+    value.  */
+    assert (false);
+}
+
+NameNamespace
+NamespaceFromName (const valtype& data)
+{
+    std::string name;
+
+    try
+    {
+        name = EncodeName (data, NameEncoding::ASCII);
+    }
+    catch (const InvalidNameString& exc)
+    {
+        return NameNamespace::NonStandard;
+    }
+
+    return NamespaceFromName(name);
+}

--- a/src/names/applications.h
+++ b/src/names/applications.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Jeremy Rand
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_BITCOIN_NAMES_APPLICATIONS
+#define H_BITCOIN_NAMES_APPLICATIONS
+
+#include <script/script.h>
+
+#include <string>
+
+enum class NameNamespace
+{
+    Domain,
+    DomainData,
+    Identity,
+    IdentityData,
+    NonStandard,
+};
+
+NameNamespace NamespaceFromName (const std::string& name);
+NameNamespace NamespaceFromName (const valtype& data);
+
+#endif // H_BITCOIN_NAMES_APPLICATIONS

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -8,6 +8,7 @@
 #include <chainparams.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
+#include <names/applications.h>
 #include <names/encoding.h>
 #include <script/names.h>
 #include <wallet/ismine.h>
@@ -128,6 +129,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     nameSub.nameOpType = TransactionRecord::NameOpType::Recv;
                 }
 
+                nameSub.nameNamespace = NamespaceFromName(nNameCredit.value().getOpName());
                 nameSub.address = EncodeNameForMessage(nNameCredit.value().getOpName());
             }
             else
@@ -141,6 +143,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
 
             if(nNameDebit.value().isAnyUpdate())
             {
+                nameSub.nameNamespace = NamespaceFromName(nNameDebit.value().getOpName());
                 nameSub.address = EncodeNameForMessage(nNameDebit.value().getOpName());
             }
         }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_TRANSACTIONRECORD_H
 
 #include <consensus/amount.h>
+#include <names/applications.h>
 #include <uint256.h>
 
 #include <QList>
@@ -99,13 +100,13 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), nameOpType(NameOpType::Other), idx(0)
+            hash(), time(0), type(Other), address(""), debit(0), credit(0), nameOpType(NameOpType::Other), nameNamespace(NameNamespace::NonStandard), idx(0)
     {
     }
 
     TransactionRecord(uint256 _hash, qint64 _time):
             hash(_hash), time(_time), type(Other), address(""), debit(0),
-            credit(0), nameOpType(NameOpType::Other), idx(0)
+            credit(0), nameOpType(NameOpType::Other), nameNamespace(NameNamespace::NonStandard), idx(0)
     {
     }
 
@@ -113,7 +114,7 @@ public:
                 Type _type, const std::string &_address,
                 const CAmount& _debit, const CAmount& _credit):
             hash(_hash), time(_time), type(_type), address(_address), debit(_debit), credit(_credit),
-            nameOpType(NameOpType::Other), idx(0)
+            nameOpType(NameOpType::Other), nameNamespace(NameNamespace::NonStandard), idx(0)
     {
     }
 
@@ -131,6 +132,7 @@ public:
     CAmount debit;
     CAmount credit;
     NameOpType nameOpType;
+    NameNamespace nameNamespace;
     /**@}*/
 
     /** Subtransaction index, for sort key */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -16,6 +16,7 @@
 
 #include <core_io.h>
 #include <interfaces/handler.h>
+#include <names/applications.h>
 #include <uint256.h>
 
 #include <algorithm>
@@ -391,24 +392,52 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::Generated:
         return tr("Mined");
     case TransactionRecord::NameOp:
+    {
+        QString namespaceStrCap;
+        QString namespaceStrLow;
+        switch(wtx->nameNamespace)
+        {
+        case NameNamespace::Domain:
+            namespaceStrCap = tr("Domain");
+            namespaceStrLow = tr("domain");
+            break;
+        case NameNamespace::DomainData:
+            namespaceStrCap = tr("Domain data");
+            namespaceStrLow = tr("domain data");
+            break;
+        case NameNamespace::Identity:
+            namespaceStrCap = tr("Identity");
+            namespaceStrLow = tr("identity");
+            break;
+        case NameNamespace::IdentityData:
+            namespaceStrCap = tr("Identity data");
+            namespaceStrLow = tr("identity data");
+            break;
+        case NameNamespace::NonStandard:
+            namespaceStrCap = tr("Non-standard name");
+            namespaceStrLow = tr("non-standard name");
+            break;
+        }
+
         switch(wtx->nameOpType)
         {
         case TransactionRecord::NameOpType::New:
             return tr("Name pre-registration");
         case TransactionRecord::NameOpType::FirstUpdate:
-            return tr("Name registration");
+            return tr("%1 registration").arg(namespaceStrCap);
         case TransactionRecord::NameOpType::Update:
-            return tr("Name update");
+            return tr("%1 update").arg(namespaceStrCap);
         case TransactionRecord::NameOpType::Renew:
-            return tr("Name renewal");
+            return tr("%1 renewal").arg(namespaceStrCap);
         case TransactionRecord::NameOpType::Recv:
-            return tr("Received name");
+            return tr("Received %1").arg(namespaceStrLow);
         case TransactionRecord::NameOpType::Send:
-            return tr("Sent name");
+            return tr("Sent %1").arg(namespaceStrLow);
         case TransactionRecord::NameOpType::Other:
             return tr("Unknown name operation");
         } // no default case, so the compiler can warn about missing cases
         assert(false);
+    }
     default:
         return QString();
     }

--- a/src/test/name_applications_tests.cpp
+++ b/src/test/name_applications_tests.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Copyright (c) 2022 The Namecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <names/applications.h>
+#include <names/encoding.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(name_applications_tests)
+
+BOOST_AUTO_TEST_CASE( namespace_detection )
+{
+    const valtype noSlash = DecodeName ("wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(noSlash) == NameNamespace::NonStandard);
+
+    const valtype weirdNamespace = DecodeName ("nft/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(weirdNamespace) == NameNamespace::NonStandard);
+
+    const valtype twoSlash = DecodeName ("d/d/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(twoSlash) == NameNamespace::NonStandard);
+
+    const valtype empty = DecodeName ("", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(empty) == NameNamespace::NonStandard);
+
+    const valtype domainValid = DecodeName ("d/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainValid) == NameNamespace::Domain);
+
+    const valtype domainShortEnough = DecodeName ("d/wikileaks-wikileaks-wikileaks-wikileaks-wikileaks-wikileaks-wik", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainShortEnough) == NameNamespace::Domain);
+
+    const valtype domainTooLong = DecodeName ("d/wikileaks-wikileaks-wikileaks-wikileaks-wikileaks-wikileaks-wiki", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainTooLong) == NameNamespace::NonStandard);
+
+    const valtype domainAllCaps = DecodeName ("d/WIKILEAKS", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainAllCaps) == NameNamespace::NonStandard);
+
+    const valtype domainOneCaps = DecodeName ("d/Wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainOneCaps) == NameNamespace::NonStandard);
+
+    const valtype domainUnderscore = DecodeName ("d/wiki_leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainUnderscore) == NameNamespace::NonStandard);
+
+    const valtype domainHyphen = DecodeName ("d/wiki-leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainHyphen) == NameNamespace::Domain);
+
+    const valtype domainDoubleHyphen = DecodeName ("d/wiki--leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainDoubleHyphen) == NameNamespace::NonStandard);
+
+    const valtype domainStartHyphen = DecodeName ("d/-wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainStartHyphen) == NameNamespace::NonStandard);
+
+    const valtype domainEndHyphen = DecodeName ("d/wikileaks-", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainEndHyphen) == NameNamespace::NonStandard);
+
+    const valtype domainIDN = DecodeName ("d/xn--wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainIDN) == NameNamespace::Domain);
+
+    const valtype domainNumeric = DecodeName ("d/123", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainNumeric) == NameNamespace::NonStandard);
+
+    const valtype domainStartNumeric = DecodeName ("d/123wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainStartNumeric) == NameNamespace::Domain);
+
+    const valtype domainNewline = DecodeName ("d/wiki\nleaks", NameEncoding::UTF8);
+    BOOST_CHECK(NamespaceFromName(domainNewline) == NameNamespace::NonStandard);
+
+    const valtype domainData = DecodeName ("dd/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(domainData) == NameNamespace::DomainData);
+
+    const valtype identityValid = DecodeName ("id/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityValid) == NameNamespace::Identity);
+
+    const valtype identityAllCaps = DecodeName ("id/WIKILEAKS", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityAllCaps) == NameNamespace::NonStandard);
+
+    const valtype identityOneCaps = DecodeName ("id/Wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityOneCaps) == NameNamespace::NonStandard);
+
+    const valtype identityUnderscore = DecodeName ("id/wiki_leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityUnderscore) == NameNamespace::NonStandard);
+
+    const valtype identityHyphen = DecodeName ("id/wiki-leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityHyphen) == NameNamespace::Identity);
+
+    const valtype identityDoubleHyphen = DecodeName ("id/wiki--leaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityDoubleHyphen) == NameNamespace::NonStandard);
+
+    const valtype identityStartHyphen = DecodeName ("id/-wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityStartHyphen) == NameNamespace::NonStandard);
+
+    const valtype identityEndHyphen = DecodeName ("id/wikileaks-", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityEndHyphen) == NameNamespace::NonStandard);
+
+    const valtype identityIDN = DecodeName ("id/xn--wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityIDN) == NameNamespace::NonStandard);
+
+    const valtype identityNumeric = DecodeName ("id/123", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityNumeric) == NameNamespace::Identity);
+
+    const valtype identityStartNumeric = DecodeName ("id/123wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityStartNumeric) == NameNamespace::Identity);
+
+    const valtype identityNewline = DecodeName ("id/wiki\nleaks", NameEncoding::UTF8);
+    BOOST_CHECK(NamespaceFromName(identityNewline) == NameNamespace::NonStandard);
+
+    const valtype identityData = DecodeName ("idd/wikileaks", NameEncoding::ASCII);
+    BOOST_CHECK(NamespaceFromName(identityData) == NameNamespace::IdentityData);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Eliminates ambiguous "name" wording in favor of "domain"/"identity"/etc.  Also has the happy side effect of producing a scary "non-standard name" warning if someone tries to do a scam by selling a domain with whitespace at the end e.g. `d/wikileaks `.