### PR TITLE
Explicitly use hex encoding in GUI to RPC API

### DIFF
--- a/src/qt/nametablemodel.h
+++ b/src/qt/nametablemodel.h
@@ -51,6 +51,9 @@ public:
     Qt::ItemFlags flags(const QModelIndex &index) const;
     /*@}*/
 
+    static QString asciiToHex(const QString &ascii);
+    static QString hexToAscii(const QString &hex);
+
     QString update(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
     QString renew(const QString &name) const;
 


### PR DESCRIPTION
Prevents corruption issues that were happening when default encoding wasn't ASCII.  Also a prereq to supporting binary data in the GUI.