### PR TITLE
MAX_VALUE_LENGTH_UI

### DIFF
--- a/src/names/main.h
+++ b/src/names/main.h
@@ -23,7 +23,7 @@ class TxValidationState;
 constexpr unsigned MAX_VALUE_LENGTH = 1023;
 constexpr unsigned MAX_NAME_LENGTH = 255;
 constexpr unsigned MIN_FIRSTUPDATE_DEPTH = 12;
-constexpr unsigned MAX_VALUE_LENGTH_UI = 520;
+constexpr unsigned MAX_VALUE_LENGTH_UI = 1023;
 
 /** The amount of coins to lock in created transactions.  */
 constexpr CAmount NAME_LOCKED_AMOUNT = COIN / 100;


### PR DESCRIPTION
Raise MAX_VALUE_LENGTH_UI to the same value as MAX_VALUE_LENGTH

**Namecoin Core does support values up to 1023 bytes**, the value however was limited in UI. To solve this issue, I raise the value to 1023 bytes from 520 bytes. 

@JeremyRand @domob1812 should review this pull request before merging it. 