### PR TITLE
Missing #include in buynamespage.h

### DIFF
--- a/src/qt/buynamespage.cpp
+++ b/src/qt/buynamespage.cpp
@@ -13,8 +13,6 @@
 
 #include <QMessageBox>
 
-#include <optional>
-
 BuyNamesPage::BuyNamesPage(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     platformStyle(platformStyle),

--- a/src/qt/buynamespage.h
+++ b/src/qt/buynamespage.h
@@ -4,6 +4,7 @@
 #include <qt/platformstyle.h>
 
 #include <QWidget>
+#include <optional>
 
 class WalletModel;
 


### PR DESCRIPTION
Both Namecoin Core 23.0 (https://github.com/namecoin/namecoin-core/issues/515) and 24.0, as shown below, fail to compile due to a missing #include.

This pull request resolves the issue in Namecoin Core 24.0 and subsequent releases. 

~~~
In file included from qt/buynamespage.cpp:1:
./qt/buynamespage.h:34:57: error: ‘optional’ in namespace ‘std’ does not name a template type
   34 |     QString firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
      |                                                         ^~~~~~~~
./qt/buynamespage.h:7:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
    6 | #include <QWidget>
  +++ |+#include <optional>
    7 | 
./qt/buynamespage.h:34:65: error: expected ‘,’ or ‘...’ before ‘<’ token
   34 |     QString firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
      |                                                                 ^
./qt/buynamespage.h:37:10: warning: ‘virtual bool BuyNamesPage::eventFilter(QObject*, QEvent*)’ can be marked override [-Wsuggest-override]
   37 |     bool eventFilter(QObject *object, QEvent *event);
      |          ^~~~~~~~~~~
qt/buynamespage.cpp: In member function ‘void BuyNamesPage::onRegisterNameAction()’:
qt/buynamespage.cpp:95:46: error: no matching function for call to ‘BuyNamesPage::firstupdate(QString&, const QString&, const std::optional<QString>&)’
   95 |     const QString err_msg = this->firstupdate(name, newValue, transferToAddress);
      |                             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./qt/buynamespage.h:34:13: note: candidate: ‘QString BuyNamesPage::firstupdate(const QString&, int) const’
   34 |     QString firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
      |             ^~~~~~~~~~~
./qt/buynamespage.h:34:13: note:   candidate expects 2 arguments, 3 provided
qt/buynamespage.cpp: At global scope:
qt/buynamespage.cpp:142:9: error: no declaration matches ‘QString BuyNamesPage::firstupdate(const QString&, const std::optional<QString>&, const std::optional<QString>&) const’
  142 | QString BuyNamesPage::firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const
      |         ^~~~~~~~~~~~
./qt/buynamespage.h:34:13: note: candidate is: ‘QString BuyNamesPage::firstupdate(const QString&, int) const’
   34 |     QString firstupdate(const QString &name, const std::optional<QString> &value, const std::optional<QString> &transferTo) const;
      |             ^~~~~~~~~~~
./qt/buynamespage.h:18:7: note: ‘class BuyNamesPage’ defined here
   18 | class BuyNamesPage : public QWidget
      |       ^~~~~~~~~~~~
make[2]: *** [Makefile:12660: qt/libbitcoinqt_a-buynamespage.o] Error 1
make[2]: Leaving directory '/home/hacker/namecoin-core-nc24.0/src'
make[1]: *** [Makefile:19356: all-recursive] Error 1
make[1]: Leaving directory '/home/hacker/namecoin-core-nc24.0/src'
make: *** [Makefile:823: all-recursive] Error 1
~~~
