### PR TITLE
Fix tab order in Configure Name dialog

### DIFF
--- a/src/qt/forms/configurenamedialog.ui
+++ b/src/qt/forms/configurenamedialog.ui
@@ -248,6 +248,12 @@
    <header>qt/qvalidatedlineedit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>dataEdit</tabstop>
+  <tabstop>transferTo</tabstop>
+  <tabstop>addressBookButton</tabstop>
+  <tabstop>pasteButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../bitcoin.qrc"/>
  </resources>


### PR DESCRIPTION
The default order prioritized the Transfer widgets over the Data widget, which was suboptimal UX.

This PR was funded by Cyphrs.