### PR TITLE
Added JSON verification functionality for the Configure Name Dialog box

### DIFF
--- a/src/names/applications.cpp
+++ b/src/names/applications.cpp
@@ -8,6 +8,8 @@
 
 #include <regex>
 
+#include <univalue.h>
+
 namespace
 {
 
@@ -174,4 +176,11 @@ DescFromName (const valtype& name, NameNamespace ns)
             return EncodeNameForMessage(name);
         }
     }
+}
+
+bool
+IsValidJSONOrEmptyString (const std::string& text){
+    UniValue v;
+
+    return text.empty() || v.read(text);
 }

--- a/src/names/applications.h
+++ b/src/names/applications.h
@@ -23,4 +23,6 @@ NameNamespace NamespaceFromName (const valtype& data);
 
 std::string DescFromName (const valtype& name, NameNamespace ns);
 
+bool IsValidJSONOrEmptyString (const std::string& text);
+
 #endif // H_BITCOIN_NAMES_APPLICATIONS

--- a/src/qt/configurenamedialog.cpp
+++ b/src/qt/configurenamedialog.cpp
@@ -8,6 +8,7 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 #include <wallet/wallet.h>
+#include <names/applications.h>
 
 #include <QMessageBox>
 #include <QClipboard>
@@ -51,6 +52,7 @@ void ConfigureNameDialog::accept()
         return;
 
     QString addr = ui->transferTo->text();
+    std::string data = ui->dataEdit->text().toStdString();
 
     if (addr != "" && !walletModel->validateAddress(addr))
     {
@@ -61,7 +63,19 @@ void ConfigureNameDialog::accept()
     returnData = ui->dataEdit->text();
     returnTransferTo = ui->transferTo->text();
 
-    QDialog::accept();
+    if(!IsValidJSONOrEmptyString(data)){
+        QMessageBox::StandardButton MessageBoxInvalidJSON = 
+        QMessageBox::warning(this, tr("Invalid JSON"),
+                tr("Are you sure you want to continue anyway? The inputted JSON data is invalid, and is likely to make the name unresolvable."), 
+                QMessageBox::Ok|QMessageBox::Cancel);
+
+        if(MessageBoxInvalidJSON == QMessageBox::Ok){
+            QDialog::accept();
+        }
+    } else {
+        QDialog::accept();
+    }
+
 }
 
 void ConfigureNameDialog::setModel(WalletModel *walletModel)
@@ -98,4 +112,13 @@ void ConfigureNameDialog::onDataEdited(const QString &name)
 {
     ui->dataSize->setText(tr("%1 / %2").arg(name.size()).arg(MAX_VALUE_LENGTH_UI));
     ui->dataSize->resize(ui->dataSize->fontMetrics().horizontalAdvance(ui->dataSize->text()), ui->dataSize->height());
+
+    std::string data = ui->dataEdit->text().toStdString();
+
+    if(IsValidJSONOrEmptyString(data)){
+        ui->labelValidJSON->setText(tr("Valid JSON text."));
+    } else {
+        ui->labelValidJSON->setText(tr("JSON data inputted is invalid."));
+    }
 }
+

--- a/src/qt/forms/configurenamedialog.ui
+++ b/src/qt/forms/configurenamedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>545</width>
-    <height>304</height>
+    <width>514</width>
+    <height>330</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -48,20 +48,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>16</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>&amp;Data:</string>
@@ -74,7 +61,37 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="3" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLineEdit" name="dataEdit">
+         <property name="toolTip">
+          <string>Enter JSON string that will be associated with the name</string>
+         </property>
+         <property name="maxLength">
+          <number>520</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="dataSize">
+         <property name="text">
+          <string>0 / 520</string>
+         </property>
+        </widget>
+     </item>
+     <!--
+       <item>
+        <widget class="QPushButton" name="btnDNSEditor">
+         <property name="text">
+          <string>DNS Editor&#8230;</string>
+         </property>
+        </widget>
+       </item>
+     -->
+     </layout>
+     </item>
+     <item row="4" column="1">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>JSON string, e.g. {&amp;quot;ip&amp;quot;: [&amp;quot;1.2.3.4&amp;quot;, &amp;quot;1.2.3.5&amp;quot;]}&lt;br&gt;See &lt;a href=&quot;https://github.com/namecoin/proposals&quot;&gt;JSON value specifications&lt;/a&gt;.</string>
@@ -84,20 +101,14 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+     <item row="5" column="1">
+      <widget class="QLabel" name="labelValidJSON">
+       <property name="text">
+        <string>TextLabel</string>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>16</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
-     <item row="7" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="labelTransferTo">
        <property name="text">
         <string>&amp;Transfer to:</string>
@@ -107,7 +118,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="6" column="1">
       <layout class="QHBoxLayout" name="transferToLayout">
        <property name="spacing">
         <number>0</number>
@@ -158,42 +169,12 @@
        </item>
       </layout>
      </item>
-     <item row="8" column="1">
+     <item row="7" column="1">
       <widget class="QLabel" name="labelTransferToHint">
        <property name="text">
         <string>(Leave empty if not transferring.)</string>
        </property>
       </widget>
-     </item>
-     <item row="4" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QLineEdit" name="dataEdit">
-         <property name="toolTip">
-          <string>Enter JSON string that will be associated with the name</string>
-         </property>
-         <property name="maxLength">
-          <number>520</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="dataSize">
-         <property name="text">
-          <string>0 / 520</string>
-         </property>
-        </widget>
-       </item>
-       <!--
-       <item>
-        <widget class="QPushButton" name="btnDNSEditor">
-         <property name="text">
-          <string>DNS Editor&#8230;</string>
-         </property>
-        </widget>
-       </item>
-       -->
-      </layout>
      </item>
     </layout>
    </item>

--- a/src/test/name_applications_tests.cpp
+++ b/src/test/name_applications_tests.cpp
@@ -119,4 +119,13 @@ BOOST_AUTO_TEST_CASE( name_description )
     BOOST_CHECK(DescFromName(identityValid, NameNamespace::Identity) == "'id/wikileaks'");
 }
 
+BOOST_AUTO_TEST_CASE( valid_json )
+{
+    BOOST_CHECK_EQUAL(IsValidJSONOrEmptyString("{\"bar\": [1,2,3]}"), true);
+    
+    BOOST_CHECK_EQUAL(IsValidJSONOrEmptyString("{\foo:"), false);
+    
+    BOOST_CHECK_EQUAL(IsValidJSONOrEmptyString(""), true);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I added JSON verification functionality in names/applications.cpp alongside the associated unit tests and added them to the configure name dialog box. The dialog box should tell you if you inputted an invalid JSON value and warn you against configuring your domain with said invalid value, but should allow you to continue anyway if you were to insist.