### PR TITLE
qt: added verification of minimal json in the configure name dialog box

### DIFF
--- a/src/names/applications.cpp
+++ b/src/names/applications.cpp
@@ -10,6 +10,8 @@
 
 #include <univalue.h>
 
+#include <logging.h>
+
 namespace
 {
 
@@ -183,4 +185,35 @@ IsValidJSONOrEmptyString (const std::string& text){
     UniValue v;
 
     return text.empty() || v.read(text);
+}    
+
+bool
+IsMinimalJSONOrEmptyString (const std::string& text){
+    UniValue v;
+    if(text.empty()){
+        return true;
+    } 
+
+    if(!v.read(text)){ 
+        return false;
+    } 
+
+    const std::string minimalJSON = GetMinimalJSON(text);
+    
+    const bool isMinimal = (text == minimalJSON);
+
+    if(!isMinimal){
+        LogDebug(BCLog::NAMES, "Minimalised JSON string is: %s \n", minimalJSON);
+    }
+
+    return isMinimal;
+}
+
+std::string
+GetMinimalJSON (const std::string& text){
+    UniValue v;
+
+    v.read(text);
+
+    return v.write(0,0);
 }

--- a/src/names/applications.h
+++ b/src/names/applications.h
@@ -25,4 +25,8 @@ std::string DescFromName (const valtype& name, NameNamespace ns);
 
 bool IsValidJSONOrEmptyString (const std::string& text);
 
+bool IsMinimalJSONOrEmptyString (const std::string& text);
+
+std::string GetMinimalJSON (const std::string& text);
+
 #endif // H_BITCOIN_NAMES_APPLICATIONS

--- a/src/qt/configurenamedialog.cpp
+++ b/src/qt/configurenamedialog.cpp
@@ -72,6 +72,33 @@ void ConfigureNameDialog::accept()
         if(MessageBoxInvalidJSON == QMessageBox::Ok){
             QDialog::accept();
         }
+
+    } else if (!IsMinimalJSONOrEmptyString(data)) {
+        QMessageBox MessageBoxNonMinimalJSON;
+        MessageBoxNonMinimalJSON.setIcon(QMessageBox::Warning);
+        MessageBoxNonMinimalJSON.setWindowTitle(tr("Non-minimal JSON"));
+        MessageBoxNonMinimalJSON.setText(tr("Are you sure you want to continue anyway? The inputted JSON data is non-minimal, and therefore will waste space as well as incurring added transaction costs when written on the blockchain.")); 
+        MessageBoxNonMinimalJSON.addButton(QMessageBox::Ok);
+        MessageBoxNonMinimalJSON.addButton(QMessageBox::Cancel);
+        MessageBoxNonMinimalJSON.addButton(tr("Minimalise JSON"), QMessageBox::ActionRole);
+        
+        MessageBoxNonMinimalJSON.exec();
+
+        QMessageBox::ButtonRole reply = MessageBoxNonMinimalJSON.buttonRole(MessageBoxNonMinimalJSON.clickedButton());
+
+        if(reply == QMessageBox::AcceptRole){
+            QDialog::accept();
+        } else if(reply == QMessageBox::ActionRole){
+            
+            std::string minimalJSONData = GetMinimalJSON(data);
+            ui->dataEdit->setText(QString::fromStdString(minimalJSONData));
+
+            returnData = QString::fromStdString(minimalJSONData);
+            data = minimalJSONData;
+
+            QDialog::accept();
+        }
+
     } else {
         QDialog::accept();
     }
@@ -114,9 +141,11 @@ void ConfigureNameDialog::onDataEdited(const QString &name)
     ui->dataSize->resize(ui->dataSize->fontMetrics().horizontalAdvance(ui->dataSize->text()), ui->dataSize->height());
 
     std::string data = ui->dataEdit->text().toStdString();
-
-    if(IsValidJSONOrEmptyString(data)){
-        ui->labelValidJSON->setText(tr("Valid JSON text."));
+    
+    if(IsMinimalJSONOrEmptyString(data)){ 
+        ui->labelValidJSON->setText(tr("Valid and minimal JSON data."));
+    } else if(IsValidJSONOrEmptyString(data)){
+        ui->labelValidJSON->setText(tr("JSON data is not minimal."));
     } else {
         ui->labelValidJSON->setText(tr("JSON data inputted is invalid."));
     }

--- a/src/test/name_applications_tests.cpp
+++ b/src/test/name_applications_tests.cpp
@@ -128,4 +128,17 @@ BOOST_AUTO_TEST_CASE( valid_json )
     BOOST_CHECK_EQUAL(IsValidJSONOrEmptyString(""), true);
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json )
+{
+    BOOST_CHECK_EQUAL(IsMinimalJSONOrEmptyString("{\"bar\":[1,2,3]}"), true);
+
+    BOOST_CHECK_EQUAL(IsMinimalJSONOrEmptyString("{\"bar\":  [1,2,3]}"), false);
+
+    BOOST_CHECK_EQUAL(IsMinimalJSONOrEmptyString("{\foo:"), false);
+
+    BOOST_CHECK_EQUAL(IsMinimalJSONOrEmptyString(""), true);
+
+    BOOST_CHECK_EQUAL(IsMinimalJSONOrEmptyString("{\"bar\":[1, 2, 3]}"), false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I added checking of JSON minimality in names/applications.cpp alongside the associated unit tests and added them to the configure name dialog box. The dialog box should tell you if you inputted an non-minimal JSON value and warn you against configuring your domain with said invalid value, but should allow you to continue anyway if you were to insist, as well as allow you to minimalise said JSON value before writing it onto the blockchain.
 
