### PR TITLE
rpc: add mineOnly to name_pending; fix optional ismine across static archives

### DIFF
--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -266,28 +266,13 @@ public:
   explicit MaybeWalletForRequest (const JSONRPCRequest& request)
   {
 #ifdef ENABLE_WALLET
-    try
-      {
-        /* GetWalletForJSONRPCRequest throws an internal error if there
-           is no wallet context.  We want to handle this situation gracefully
-           and just fall back to not having a wallet in this case.  */
-        if (util::AnyPtr<wallet::WalletContext> (request.context))
-          {
-            wallet = wallet::GetWalletForJSONRPCRequest (request);
-            return;
-          }
-      }
-    catch (const UniValue& exc)
-      {
-        const auto& code = exc["code"];
-        if (!code.isNum () || code.getInt<int> () != RPC_WALLET_NOT_SPECIFIED)
-          throw;
-
-      }
-
-    /* If the wallet is not set, that's fine, and we just indicate it to
-       other code (by having a null wallet).  */
-    wallet = nullptr;
+    /* Resolve the wallet via a wallet-side helper so the WalletContext
+       typeid lookup happens in the wallet translation unit.  Calling
+       util::AnyPtr<WalletContext> from this node-side TU yields a false
+       negative on platforms where typeinfo for wallet::WalletContext is
+       duplicated across the static node and wallet libraries (notably
+       macOS clang).  */
+    wallet = wallet::MaybeGetWalletForJSONRPCRequest (request);
 #endif
   }
 

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -789,7 +789,9 @@ name_pending ()
   NameOptionsHelp optHelp;
   optHelp
       .withNameEncoding ()
-      .withValueEncoding ();
+      .withValueEncoding ()
+      .withArg ("mineOnly", RPCArg::Type::BOOL, "false",
+                "Only return entries for names owned by the loaded wallet");
 
   return RPCMethod ("name_pending",
       "Lists unconfirmed name operations in the mempool.\n"
@@ -808,6 +810,7 @@ name_pending ()
       RPCExamples {
           HelpExampleCli ("name_pending", "")
         + HelpExampleCli ("name_pending", "\"d/domob\"")
+        + HelpExampleCli ("name_pending", "null '{\"mineOnly\":true}'")
         + HelpExampleRpc ("name_pending", "")
       },
       [&] (const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
@@ -825,6 +828,20 @@ name_pending ()
   if (hasNameFilter)
     nameFilter = DecodeNameFromRPCOrThrow (request.params[0], options);
 
+  bool mineOnly = false;
+  if (options.exists ("mineOnly"))
+    mineOnly = options["mineOnly"].get_bool ();
+#ifdef ENABLE_WALLET
+  const wallet::CWallet* const pwalletForMine = mineOnly ? wallet.getWallet () : nullptr;
+  if (mineOnly && pwalletForMine == nullptr)
+    throw JSONRPCError (RPC_WALLET_NOT_FOUND,
+                        "mineOnly requires a wallet to be loaded");
+#else
+  if (mineOnly)
+    throw JSONRPCError (RPC_METHOD_NOT_FOUND,
+                        "mineOnly requires wallet support, which is disabled");
+#endif
+
   UniValue arr(UniValue::VARR);
   for (const CTxMemPoolEntry& entry : mempool.entryAll ())
     {
@@ -840,6 +857,10 @@ name_pending ()
             continue;
           if (hasNameFilter && op.getOpName () != nameFilter)
             continue;
+#ifdef ENABLE_WALLET
+          if (mineOnly && !pwalletForMine->IsMine (op.getAddress ()))
+            continue;
+#endif
 
           UniValue obj = getNameInfo (options,
                                       op.getOpName (), op.getOpValue (),

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -98,6 +98,33 @@ WalletContext& EnsureWalletContext(const std::any& context)
     return *wallet_context;
 }
 
+std::shared_ptr<CWallet> MaybeGetWalletForJSONRPCRequest(const JSONRPCRequest& request)
+{
+    /* This helper performs the wallet lookup inside the wallet translation
+       unit, where the RTTI for wallet::WalletContext is canonical.  Calling
+       util::AnyPtr<WalletContext> from a node-side TU can yield a false
+       negative on platforms where the typeid for WalletContext is duplicated
+       across the static node and wallet libraries (notably macOS clang with
+       hidden-default visibility for typeinfo).  Returning a null shared_ptr
+       on absence (rather than throwing RPC_INTERNAL_ERROR) lets callers that
+       treat the wallet as optional (e.g. for an "ismine" annotation) degrade
+       gracefully.  */
+    if (!util::AnyPtr<WalletContext>(request.context)) {
+        return nullptr;
+    }
+    try {
+        return GetWalletForJSONRPCRequest(request);
+    } catch (const UniValue& exc) {
+        const UniValue& code = exc["code"];
+        if (!code.isNum()) throw;
+        const int err = code.getInt<int>();
+        if (err == RPC_WALLET_NOT_FOUND || err == RPC_WALLET_NOT_SPECIFIED) {
+            return nullptr;
+        }
+        throw;
+    }
+}
+
 std::string LabelFromValue(const UniValue& value)
 {
     static const std::string empty_string;

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -39,6 +39,16 @@ static const RPCResult RESULT_LAST_PROCESSED_BLOCK { RPCResult::Type::OBJ, "last
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+
+/** Like GetWalletForJSONRPCRequest, but returns a null shared_ptr instead of
+ *  throwing when no wallet context is attached, no wallet is loaded, or the
+ *  selection is ambiguous.  Use this for optional wallet annotations on
+ *  otherwise wallet-agnostic RPCs (e.g. the "ismine" field).  Resolving the
+ *  wallet context inside the wallet translation unit avoids the typeid
+ *  duplication that can occur when std::any_cast<WalletContext*> is invoked
+ *  from a different static archive (e.g. the node library) on platforms with
+ *  hidden-default RTTI visibility (notably macOS).  */
+std::shared_ptr<CWallet> MaybeGetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 std::optional<std::string> GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request);
 /**
  * Ensures that a wallet name is specified across the endpoint and wallet_name.

--- a/test/functional/name_pending_mineonly.py
+++ b/test/functional/name_pending_mineonly.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Namecoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for the {"mineOnly": true} option of name_pending.
+#
+# Two nodes share a mempool.  Node 0 first registers a name and then
+# transfers it to an address owned by node 1 via name_update.  While the
+# update sits in the mempool, name_pending must respect mineOnly:true on
+# both sides.
+#
+# Wallet-scoped RPC endpoints are used so that the wallet context is always
+# attached to the request.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class NamePendingMineOnlyTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 2)
+
+  def run_test (self):
+    node0 = self.nodes[0].get_wallet_rpc (self.default_wallet_name)
+    node1 = self.nodes[1].get_wallet_rpc (self.default_wallet_name)
+
+    # ----- Setup: register name "a" on node 0 -----
+    newA = node0.name_new ("a")
+    self.generate (self.nodes[0], 12)
+    self.firstupdateName (0, "a", newA, "value-a")
+    self.generate (self.nodes[0], 1)
+    self.sync_blocks ()
+
+    # ----- Pending update owned by node 0 -----
+    txMine0 = node0.name_update ("a", "value-a-2")
+    self.sync_mempools ()
+
+    # Default behavior unchanged: both nodes see the pending op.
+    assert_equal (len (node0.name_pending ()), 1)
+    assert_equal (len (node1.name_pending ()), 1)
+
+    # mineOnly:false explicitly equals the default.
+    assert_equal (
+        [e['txid'] for e in node0.name_pending (None, {"mineOnly": False})],
+        [e['txid'] for e in node0.name_pending ()])
+
+    # mineOnly:true returns only entries owned by the calling wallet.
+    mine0 = node0.name_pending (None, {"mineOnly": True})
+    assert_equal (len (mine0), 1)
+    assert_equal (mine0[0]['name'], 'a')
+    assert_equal (mine0[0]['txid'], txMine0)
+    assert_equal (mine0[0]['ismine'], True)
+    assert_equal (node1.name_pending (None, {"mineOnly": True}), [])
+
+    # mineOnly composes with the name filter.
+    assert_equal (
+        node0.name_pending ('a', {"mineOnly": True})[0]['txid'], txMine0)
+    assert_equal (node0.name_pending ('does not exist',
+                                      {"mineOnly": True}), [])
+    assert_equal (node1.name_pending ('a', {"mineOnly": True}), [])
+
+    # Mine, sync, and clear the mempool before the next scenario.
+    self.generate (self.nodes[0], 1)
+    self.sync_blocks ()
+    assert_equal (node0.name_pending (), [])
+    assert_equal (node1.name_pending (), [])
+
+    # ----- Pending transfer: ownership flips between wallets -----
+    addrOther = node1.getnewaddress ()
+    txTransfer = node0.name_update ("a", "sent-a", {"destAddress": addrOther})
+    self.sync_mempools ()
+
+    # The pending output's destination is owned by node 1, so:
+    #   * node 0 -> mineOnly:true -> []
+    #   * node 1 -> mineOnly:true -> 1 entry, ismine=true
+    assert_equal (node0.name_pending (None, {"mineOnly": True}), [])
+    pending1 = node1.name_pending (None, {"mineOnly": True})
+    assert_equal (len (pending1), 1)
+    assert_equal (pending1[0]['txid'], txTransfer)
+    assert_equal (pending1[0]['name'], 'a')
+    assert_equal (pending1[0]['ismine'], True)
+
+    # ----- Error: mineOnly when no wallet is loaded -----
+    # Unload the default wallet and confirm mineOnly errors out cleanly
+    # rather than silently returning everything.
+    self.nodes[0].unloadwallet (self.default_wallet_name)
+    assert_raises_rpc_error (
+        -18, "mineOnly requires a wallet to be loaded",
+        self.nodes[0].name_pending, None, {"mineOnly": True})
+    # Default behavior (no mineOnly) still works without a wallet.
+    assert isinstance (self.nodes[0].name_pending (), list)
+    self.nodes[0].loadwallet (self.default_wallet_name)
+
+
+if __name__ == '__main__':
+  NamePendingMineOnlyTest (__file__).main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -417,6 +417,7 @@ BASE_SCRIPTS = [
     'name_multiupdate.py',
     'name_novalue.py',
     'name_pending.py',
+    'name_pending_mineonly.py',
     'name_psbt.py',
     'name_rawtx.py',
     'name_registration.py',


### PR DESCRIPTION
## What

Two related changes to the `name_pending` RPC and its supporting wallet plumbing.

### Commit 1 — `rpc: fix optional ismine on name_pending et al. across static archives`

The `MaybeWalletForRequest` helper in `src/rpc/names.cpp` is responsible for attaching the active wallet to the request so `name_show`, `name_history`, `name_scan`, and `name_pending` can decorate their results with an `ismine` field. The original implementation gated the wallet lookup on `util::AnyPtr<wallet::WalletContext>(request.context)` from `src/rpc/names.cpp`, which lives in the `bitcoin_node` static archive.

On platforms where `typeinfo` for `wallet::WalletContext` ends up duplicated across the `bitcoin_node` and `bitcoin_wallet` archives (notably macOS clang with default hidden-typeinfo visibility), the `typeid` stored in `request.context` (set in `src/wallet/interfaces.cpp` inside `bitcoin_wallet`) does not compare equal to the `typeid` resolved from the node-side TU, even though the demangled type-name string is identical. Concretely I observed:

```
DBG MaybeWalletForRequest stored='PN6wallet13WalletContextE' (0x105818670) \
                          expected='PN6wallet13WalletContextE' (0x10580fb50) \
                          eq=0 uri='/wallet/default_wallet'
```

As a result, the `AnyPtr` check returned null, `MaybeWalletForRequest` fell through to "no wallet", and `ismine` never appeared on those RPCs on macOS local builds. (`name_pending.py` has been failing locally for me on `master` for this reason; it predates this PR. It passes again with this fix.)

The fix moves the wallet lookup into a new wallet-side helper, `wallet::MaybeGetWalletForJSONRPCRequest`, defined in `src/wallet/rpc/util.{h,cpp}`. Doing the typeid comparison inside the same translation unit that originally stored the `WalletContext` pointer sidesteps the duplicated-typeinfo problem entirely. The helper also collapses the three "no wallet available" cases (no wallet context, no wallet loaded, multiple wallets with no `/wallet/<name>` selection) into a single null return — exactly the contract `MaybeWalletForRequest`'s old try/catch was approximating.

### Commit 2 — `rpc: add mineOnly option to name_pending`

Adds a `{"mineOnly": true}` option to `name_pending` that filters the result to only the unconfirmed name operations whose output address is owned by the loaded wallet. The default remains `false`, so existing callers see no behavior change.

Motivation: a wallet UI that polls `name_pending` to track its own pending registrations and updates currently has to walk every pending name operation in the mempool on every poll and discard most of them client side. That is fine on a quiet chain but scales linearly with overall pending name traffic, and ships an arbitrarily large JSON payload to the client just so it can throw most of it away. With `mineOnly:true`, the filter happens server side, before `getNameInfo` / `addOwnershipInfo` run, so the wallet pays roughly O(its own pending ops) instead of O(all pending name ops in the mempool).

Behavior:

* `mineOnly` is opt-in; default `false`.
* `mineOnly:true` requires a wallet to be loaded. When `ENABLE_WALLET` is defined and no wallet is loaded (or the request is otherwise ambiguous, e.g. multiple wallets with no `/wallet/<name>` selection), the call returns `RPC_WALLET_NOT_FOUND` with a clear message rather than silently returning everything.
* When `ENABLE_WALLET` is undefined, `mineOnly:true` returns `RPC_METHOD_NOT_FOUND`.
* `mineOnly:true` composes with the existing `name` filter and with `nameEncoding` / `valueEncoding`.

## Tests

A new functional test, `test/functional/name_pending_mineonly.py`, covers:

* `mineOnly:false` matches the default,
* `mineOnly:true` with a self-owned pending update,
* a transferred pending update where ownership flips between two wallets in the mempool,
* `mineOnly` composing with the name filter and the "does not exist" case,
* `mineOnly` without a wallet erroring with `RPC_WALLET_NOT_FOUND`.

I ran the full `name_*.py` battery locally on macOS arm64 with both commits applied — all 27 tests pass:

```
name_allowexpired.py            | ✓ Passed  |  2 s
name_ant_workflow.py            | ✓ Passed  |  4 s
name_bumpfee.py                 | ✓ Passed  |  2 s
name_byhash.py                  | ✓ Passed  |  1 s
name_encodings.py               | ✓ Passed  | 15 s
name_expiration.py              | ✓ Passed  |  1 s
name_immature_inputs.py         | ✓ Passed  | 27 s
name_ismine.py                  | ✓ Passed  |  2 s
name_list.py                    | ✓ Passed  |  4 s
name_listunspent.py             | ✓ Passed  |  8 s
name_longsalt.py                | ✓ Passed  |  2 s
name_multisig.py                | ✓ Passed  | 14 s
name_multisig.py --bip16-active | ✓ Passed  | 14 s
name_multiupdate.py             | ✓ Passed  |  0 s
name_novalue.py                 | ✓ Passed  |  0 s
name_pending.py                 | ✓ Passed  |  6 s
name_pending_mineonly.py        | ✓ Passed  | 13 s
name_psbt.py                    | ✓ Passed  |  3 s
name_rawtx.py                   | ✓ Passed  |  5 s
name_registration.py            | ✓ Passed  | 22 s
name_reorg.py                   | ✓ Passed  |  1 s
name_scanning.py                | ✓ Passed  |  1 s
name_segwit.py                  | ✓ Passed  |  0 s
name_sendcoins.py               | ✓ Passed  |  1 s
name_txnqueue.py                | ✓ Passed  |  0 s
name_utxo.py                    | ✓ Passed  |  0 s
name_wallet.py                  | ✓ Passed  | 10 s
```

Build: macOS 15 arm64, clang from Xcode toolchain, CMake build with default flags, `ENABLE_WALLET=ON`.

## Notes on splitting

I split the underlying ismine fix and the `mineOnly` feature into two commits so the typeinfo-duplication fix is reviewable on its own and can be cherry-picked separately if desired. The order matters: without commit 1, the `mineOnly` test would intermittently fail to see `ismine` on macOS builds, and the new `pwalletForMine = wallet.getWallet()` lookup in commit 2 would return null on platforms where the typeinfo bug bites.

I'm happy to split this into two PRs if reviewers prefer that.
