### PR TITLE
rpc: add includePending option to name_list

### DIFF
--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -266,28 +266,13 @@ public:
   explicit MaybeWalletForRequest (const JSONRPCRequest& request)
   {
 #ifdef ENABLE_WALLET
-    try
-      {
-        /* GetWalletForJSONRPCRequest throws an internal error if there
-           is no wallet context.  We want to handle this situation gracefully
-           and just fall back to not having a wallet in this case.  */
-        if (util::AnyPtr<wallet::WalletContext> (request.context))
-          {
-            wallet = wallet::GetWalletForJSONRPCRequest (request);
-            return;
-          }
-      }
-    catch (const UniValue& exc)
-      {
-        const auto& code = exc["code"];
-        if (!code.isNum () || code.getInt<int> () != RPC_WALLET_NOT_SPECIFIED)
-          throw;
-
-      }
-
-    /* If the wallet is not set, that's fine, and we just indicate it to
-       other code (by having a null wallet).  */
-    wallet = nullptr;
+    /* Resolve the wallet via a wallet-side helper so the WalletContext
+       typeid lookup happens in the wallet translation unit.  Calling
+       util::AnyPtr<WalletContext> from this node-side TU yields a false
+       negative on platforms where typeinfo for wallet::WalletContext is
+       duplicated across the static node and wallet libraries (notably
+       macOS clang).  */
+    wallet = wallet::MaybeGetWalletForJSONRPCRequest (request);
 #endif
   }
 

--- a/src/rpc/names.cpp
+++ b/src/rpc/names.cpp
@@ -789,7 +789,9 @@ name_pending ()
   NameOptionsHelp optHelp;
   optHelp
       .withNameEncoding ()
-      .withValueEncoding ();
+      .withValueEncoding ()
+      .withArg ("mineOnly", RPCArg::Type::BOOL, "false",
+                "Only return entries for names owned by the loaded wallet");
 
   return RPCMethod ("name_pending",
       "Lists unconfirmed name operations in the mempool.\n"
@@ -808,6 +810,7 @@ name_pending ()
       RPCExamples {
           HelpExampleCli ("name_pending", "")
         + HelpExampleCli ("name_pending", "\"d/domob\"")
+        + HelpExampleCli ("name_pending", "null '{\"mineOnly\":true}'")
         + HelpExampleRpc ("name_pending", "")
       },
       [&] (const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
@@ -825,6 +828,20 @@ name_pending ()
   if (hasNameFilter)
     nameFilter = DecodeNameFromRPCOrThrow (request.params[0], options);
 
+  bool mineOnly = false;
+  if (options.exists ("mineOnly"))
+    mineOnly = options["mineOnly"].get_bool ();
+#ifdef ENABLE_WALLET
+  const wallet::CWallet* const pwalletForMine = mineOnly ? wallet.getWallet () : nullptr;
+  if (mineOnly && pwalletForMine == nullptr)
+    throw JSONRPCError (RPC_WALLET_NOT_FOUND,
+                        "mineOnly requires a wallet to be loaded");
+#else
+  if (mineOnly)
+    throw JSONRPCError (RPC_METHOD_NOT_FOUND,
+                        "mineOnly requires wallet support, which is disabled");
+#endif
+
   UniValue arr(UniValue::VARR);
   for (const CTxMemPoolEntry& entry : mempool.entryAll ())
     {
@@ -840,6 +857,10 @@ name_pending ()
             continue;
           if (hasNameFilter && op.getOpName () != nameFilter)
             continue;
+#ifdef ENABLE_WALLET
+          if (mineOnly && !pwalletForMine->IsMine (op.getAddress ()))
+            continue;
+#endif
 
           UniValue obj = getNameInfo (options,
                                       op.getOpName (), op.getOpValue (),

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -98,6 +98,33 @@ WalletContext& EnsureWalletContext(const std::any& context)
     return *wallet_context;
 }
 
+std::shared_ptr<CWallet> MaybeGetWalletForJSONRPCRequest(const JSONRPCRequest& request)
+{
+    /* This helper performs the wallet lookup inside the wallet translation
+       unit, where the RTTI for wallet::WalletContext is canonical.  Calling
+       util::AnyPtr<WalletContext> from a node-side TU can yield a false
+       negative on platforms where the typeid for WalletContext is duplicated
+       across the static node and wallet libraries (notably macOS clang with
+       hidden-default visibility for typeinfo).  Returning a null shared_ptr
+       on absence (rather than throwing RPC_INTERNAL_ERROR) lets callers that
+       treat the wallet as optional (e.g. for an "ismine" annotation) degrade
+       gracefully.  */
+    if (!util::AnyPtr<WalletContext>(request.context)) {
+        return nullptr;
+    }
+    try {
+        return GetWalletForJSONRPCRequest(request);
+    } catch (const UniValue& exc) {
+        const UniValue& code = exc["code"];
+        if (!code.isNum()) throw;
+        const int err = code.getInt<int>();
+        if (err == RPC_WALLET_NOT_FOUND || err == RPC_WALLET_NOT_SPECIFIED) {
+            return nullptr;
+        }
+        throw;
+    }
+}
+
 std::string LabelFromValue(const UniValue& value)
 {
     static const std::string empty_string;

--- a/src/wallet/rpc/util.h
+++ b/src/wallet/rpc/util.h
@@ -39,6 +39,16 @@ static const RPCResult RESULT_LAST_PROCESSED_BLOCK { RPCResult::Type::OBJ, "last
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+
+/** Like GetWalletForJSONRPCRequest, but returns a null shared_ptr instead of
+ *  throwing when no wallet context is attached, no wallet is loaded, or the
+ *  selection is ambiguous.  Use this for optional wallet annotations on
+ *  otherwise wallet-agnostic RPCs (e.g. the "ismine" field).  Resolving the
+ *  wallet context inside the wallet translation unit avoids the typeid
+ *  duplication that can occur when std::any_cast<WalletContext*> is invoked
+ *  from a different static archive (e.g. the node library) on platforms with
+ *  hidden-default RTTI visibility (notably macOS).  */
+std::shared_ptr<CWallet> MaybeGetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 std::optional<std::string> GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request);
 /**
  * Ensures that a wallet name is specified across the endpoint and wallet_name.

--- a/src/wallet/rpc/walletnames.cpp
+++ b/src/wallet/rpc/walletnames.cpp
@@ -187,7 +187,12 @@ name_list ()
   NameOptionsHelp optHelp;
   optHelp
       .withNameEncoding ()
-      .withValueEncoding ();
+      .withValueEncoding ()
+      .withArg ("includePending", RPCArg::Type::BOOL, "false",
+                "Also include unconfirmed wallet name operations from the mempool. "
+                "Pending entries replace the confirmed entry for the same name and "
+                "have a \"pending\" field set to true and an \"op\" field describing "
+                "the unconfirmed operation");
 
   return RPCMethod ("name_list",
       "Shows the status of all names in the wallet.\n",
@@ -198,13 +203,26 @@ name_list ()
       RPCResult {RPCResult::Type::ARR, "", "",
           {
               NameInfoHelp ()
-                .withExpiration ()
+                .withField ({RPCResult::Type::NUM, "height", true,
+                             "the name's last update height (omitted for pending entries)"})
+                .withField ({RPCResult::Type::NUM, "expires_in", true,
+                             "expire counter for the name (omitted for pending entries)"})
+                .withField ({RPCResult::Type::BOOL, "expired", true,
+                             "whether the name is expired (omitted for pending entries)"})
+                .withField ({RPCResult::Type::BOOL, "pending", true,
+                             "true if this entry comes from the mempool (only "
+                             "present when includePending is set)"})
+                .withField ({RPCResult::Type::STR, "op", true,
+                             "the pending operation (only present when this "
+                             "entry is pending): \"name_firstupdate\" or "
+                             "\"name_update\""})
                 .finish ()
           }
       },
       RPCExamples {
           HelpExampleCli ("name_list", "")
         + HelpExampleCli ("name_list", "\"myname\"")
+        + HelpExampleCli ("name_list", "null '{\"includePending\":true}'")
         + HelpExampleRpc ("name_list", "")
       },
       [&] (const RPCMethod& self, const JSONRPCRequest& request) -> UniValue
@@ -224,8 +242,16 @@ name_list ()
   if (request.params.size () >= 1 && !request.params[0].isNull ())
     nameFilter = DecodeNameFromRPCOrThrow (request.params[0], options);
 
+  bool includePending = false;
+  if (options.exists ("includePending"))
+    includePending = options["includePending"].get_bool ();
+
   std::map<valtype, int> mapHeights;
   std::map<valtype, UniValue> mapObjects;
+  /* Names with a pending wallet name op.  Pending entries always win
+     over any confirmed entry for the same name, since the wallet's
+     intent is the more recent state.  */
+  std::set<valtype> pendingNames;
 
   /* Make sure the results are valid at least up to the most recent block
      the user could have gotten from another RPC command prior to now.  */
@@ -266,10 +292,44 @@ name_list ()
         continue;
 
       const int depth = pwallet->GetTxDepthInMainChain(tx);
-      if (depth <= 0)
-        continue;
-      const int height = tipHeight - depth + 1;
+      const bool isPending = (depth <= 0);
 
+      if (isPending && (!includePending || tx.isAbandoned ()))
+        continue;
+
+      if (isPending)
+        {
+          /* Among multiple pending wallet txs for the same name, prefer
+             the one we saw most recently (highest nOrderPos).  */
+          if (pendingNames.count (name) > 0)
+            {
+              const auto mit = mapHeights.find (name);
+              if (mit != mapHeights.end () && mit->second >= tx.nOrderPos)
+                continue;
+            }
+
+          UniValue obj
+            = getNameInfo (options, name, nameOp.getOpValue (),
+                           COutPoint (tx.GetHash (), nOut),
+                           nameOp.getAddress ());
+          addOwnershipInfo (nameOp.getAddress (), pwallet, obj);
+          obj.pushKV ("pending", true);
+          obj.pushKV ("op",
+                      nameOp.getNameOp () == OP_NAME_FIRSTUPDATE
+                          ? "name_firstupdate"
+                          : "name_update");
+
+          pendingNames.insert (name);
+          mapHeights[name] = tx.nOrderPos;
+          mapObjects[name] = obj;
+          continue;
+        }
+
+      /* If a pending wallet op already covers this name, that wins.  */
+      if (pendingNames.count (name) > 0)
+        continue;
+
+      const int height = tipHeight - depth + 1;
       const auto mit = mapHeights.find (name);
       if (mit != mapHeights.end () && mit->second > height)
         continue;

--- a/test/functional/name_list_pending.py
+++ b/test/functional/name_list_pending.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Namecoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for the {"includePending": true} option of name_list.
+#
+# name_list normally returns only confirmed wallet names.  With
+# includePending:true it also returns the wallet's unconfirmed name
+# operations from the mempool, marked with {"pending": true} and an
+# "op" field.  A pending entry replaces the confirmed entry for the
+# same name.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import assert_equal
+
+
+class NameListPendingTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 1)
+
+  def run_test (self):
+    node = self.nodes[0].get_wallet_rpc (self.default_wallet_name)
+
+    # Register two names "a" and "b".
+    newA = node.name_new ("a")
+    newB = node.name_new ("b")
+    self.generate (self.nodes[0], 12)
+    self.firstupdateName (0, "a", newA, "value-a-1")
+    self.firstupdateName (0, "b", newB, "value-b-1")
+    self.generate (self.nodes[0], 1)
+
+    # ----- Confirmed-only baseline -----
+    confirmed = sorted (node.name_list (), key=lambda e: e['name'])
+    assert_equal ([e['name'] for e in confirmed], ['a', 'b'])
+    assert_equal ([e['value'] for e in confirmed], ['value-a-1', 'value-b-1'])
+    for e in confirmed:
+      assert 'pending' not in e
+      assert 'op' not in e
+
+    # includePending without any pending tx is identical to default.
+    assert_equal (
+        sorted (node.name_list (None, {"includePending": True}),
+                key=lambda e: e['name']),
+        confirmed)
+
+    # ----- Pending name_update -----
+    txUpd = node.name_update ("a", "value-a-2")
+    assert txUpd in self.nodes[0].getrawmempool ()
+
+    # Default name_list still shows the confirmed value for "a".
+    default_after = sorted (node.name_list (), key=lambda e: e['name'])
+    assert_equal ([e['value'] for e in default_after],
+                  ['value-a-1', 'value-b-1'])
+    for e in default_after:
+      assert 'pending' not in e
+
+    # includePending shows the pending value for "a", confirmed for "b".
+    pending_view = sorted (
+        node.name_list (None, {"includePending": True}),
+        key=lambda e: e['name'])
+    assert_equal ([e['name'] for e in pending_view], ['a', 'b'])
+
+    a_entry = pending_view[0]
+    assert_equal (a_entry['name'], 'a')
+    assert_equal (a_entry['value'], 'value-a-2')
+    assert_equal (a_entry['pending'], True)
+    assert_equal (a_entry['op'], 'name_update')
+    assert_equal (a_entry['txid'], txUpd)
+    assert_equal (a_entry['ismine'], True)
+
+    b_entry = pending_view[1]
+    assert_equal (b_entry['name'], 'b')
+    assert_equal (b_entry['value'], 'value-b-1')
+    assert 'pending' not in b_entry, b_entry
+
+    # The name filter composes with includePending.
+    only_a = node.name_list ('a', {"includePending": True})
+    assert_equal (len (only_a), 1)
+    assert_equal (only_a[0]['name'], 'a')
+    assert_equal (only_a[0]['pending'], True)
+
+    only_b = node.name_list ('b', {"includePending": True})
+    assert_equal (len (only_b), 1)
+    assert 'pending' not in only_b[0]
+
+    # ----- After confirmation, pending becomes confirmed -----
+    self.generate (self.nodes[0], 1)
+    confirmed_after = sorted (
+        node.name_list (None, {"includePending": True}),
+        key=lambda e: e['name'])
+    assert_equal ([e['value'] for e in confirmed_after],
+                  ['value-a-2', 'value-b-1'])
+    for e in confirmed_after:
+      assert 'pending' not in e
+      assert 'op' not in e
+
+
+if __name__ == '__main__':
+  NameListPendingTest (__file__).main ()

--- a/test/functional/name_pending_mineonly.py
+++ b/test/functional/name_pending_mineonly.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Namecoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# RPC test for the {"mineOnly": true} option of name_pending.
+#
+# Two nodes share a mempool.  Node 0 first registers a name and then
+# transfers it to an address owned by node 1 via name_update.  While the
+# update sits in the mempool, name_pending must respect mineOnly:true on
+# both sides.
+#
+# Wallet-scoped RPC endpoints are used so that the wallet context is always
+# attached to the request.
+
+from test_framework.names import NameTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class NamePendingMineOnlyTest (NameTestFramework):
+
+  def set_test_params (self):
+    self.setup_name_test ([[]] * 2)
+
+  def run_test (self):
+    node0 = self.nodes[0].get_wallet_rpc (self.default_wallet_name)
+    node1 = self.nodes[1].get_wallet_rpc (self.default_wallet_name)
+
+    # ----- Setup: register name "a" on node 0 -----
+    newA = node0.name_new ("a")
+    self.generate (self.nodes[0], 12)
+    self.firstupdateName (0, "a", newA, "value-a")
+    self.generate (self.nodes[0], 1)
+    self.sync_blocks ()
+
+    # ----- Pending update owned by node 0 -----
+    txMine0 = node0.name_update ("a", "value-a-2")
+    self.sync_mempools ()
+
+    # Default behavior unchanged: both nodes see the pending op.
+    assert_equal (len (node0.name_pending ()), 1)
+    assert_equal (len (node1.name_pending ()), 1)
+
+    # mineOnly:false explicitly equals the default.
+    assert_equal (
+        [e['txid'] for e in node0.name_pending (None, {"mineOnly": False})],
+        [e['txid'] for e in node0.name_pending ()])
+
+    # mineOnly:true returns only entries owned by the calling wallet.
+    mine0 = node0.name_pending (None, {"mineOnly": True})
+    assert_equal (len (mine0), 1)
+    assert_equal (mine0[0]['name'], 'a')
+    assert_equal (mine0[0]['txid'], txMine0)
+    assert_equal (mine0[0]['ismine'], True)
+    assert_equal (node1.name_pending (None, {"mineOnly": True}), [])
+
+    # mineOnly composes with the name filter.
+    assert_equal (
+        node0.name_pending ('a', {"mineOnly": True})[0]['txid'], txMine0)
+    assert_equal (node0.name_pending ('does not exist',
+                                      {"mineOnly": True}), [])
+    assert_equal (node1.name_pending ('a', {"mineOnly": True}), [])
+
+    # Mine, sync, and clear the mempool before the next scenario.
+    self.generate (self.nodes[0], 1)
+    self.sync_blocks ()
+    assert_equal (node0.name_pending (), [])
+    assert_equal (node1.name_pending (), [])
+
+    # ----- Pending transfer: ownership flips between wallets -----
+    addrOther = node1.getnewaddress ()
+    txTransfer = node0.name_update ("a", "sent-a", {"destAddress": addrOther})
+    self.sync_mempools ()
+
+    # The pending output's destination is owned by node 1, so:
+    #   * node 0 -> mineOnly:true -> []
+    #   * node 1 -> mineOnly:true -> 1 entry, ismine=true
+    assert_equal (node0.name_pending (None, {"mineOnly": True}), [])
+    pending1 = node1.name_pending (None, {"mineOnly": True})
+    assert_equal (len (pending1), 1)
+    assert_equal (pending1[0]['txid'], txTransfer)
+    assert_equal (pending1[0]['name'], 'a')
+    assert_equal (pending1[0]['ismine'], True)
+
+    # ----- Error: mineOnly when no wallet is loaded -----
+    # Unload the default wallet and confirm mineOnly errors out cleanly
+    # rather than silently returning everything.
+    self.nodes[0].unloadwallet (self.default_wallet_name)
+    assert_raises_rpc_error (
+        -18, "mineOnly requires a wallet to be loaded",
+        self.nodes[0].name_pending, None, {"mineOnly": True})
+    # Default behavior (no mineOnly) still works without a wallet.
+    assert isinstance (self.nodes[0].name_pending (), list)
+    self.nodes[0].loadwallet (self.default_wallet_name)
+
+
+if __name__ == '__main__':
+  NamePendingMineOnlyTest (__file__).main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -417,6 +417,7 @@ BASE_SCRIPTS = [
     'name_multiupdate.py',
     'name_novalue.py',
     'name_pending.py',
+    'name_pending_mineonly.py',
     'name_psbt.py',
     'name_rawtx.py',
     'name_registration.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -410,6 +410,7 @@ BASE_SCRIPTS = [
     'name_immature_inputs.py',
     'name_ismine.py',
     'name_list.py',
+    'name_list_pending.py',
     'name_listunspent.py',
     'name_longsalt.py',
     'name_multisig.py',


### PR DESCRIPTION
## What

Adds an `{"includePending": true}` option to the `name_list` RPC that includes the wallet's unconfirmed name operations from the mempool alongside its confirmed names. Default is `false`, so existing callers see no change.

## Why

Today a wallet UI that wants "my names, current state" has to:

1. Call `name_list` for the wallet's confirmed names.
2. Call `name_pending` (now with `mineOnly:true` from #585) for the wallet's pending name ops.
3. Merge them client-side, replacing any confirmed entry whose name has a more recent pending update.

Every Namecoin wallet UI ends up duplicating that merge logic. Even this repo's QT name table model (`src/qt/nametablemodel.cpp`) does the same dance:

```cpp
confirmedNames = parent.walletModel->node().executeRpc("name_list", params, walletURI);
...
pendingNames = parent.walletModel->node().executeRpc("name_pending", params, walletURI);
```

With `includePending:true` the merge happens server-side, in the place that already has both pieces of data and the right locks.

## Behavior

* **Opt-in.** Default `includePending:false` preserves the previous behavior byte-for-byte.
* When set, `name_list` also walks `pwallet->mapWallet` for unconfirmed wallet txs (`depth <= 0`) and emits an entry per name op.
* Pending entries are decorated with:
  * `"pending": true`
  * `"op"`: either `"name_firstupdate"` or `"name_update"`
* A pending entry **replaces** any confirmed entry for the same name. The wallet's pending op is its more recent intended state, so a UI that respects the pending row matches what the chain will look like once the tx confirms.
* If multiple pending wallet txs touch the same name (e.g. an RBF chain that hasn't been pruned from the wallet), the one with the highest `nOrderPos` wins — i.e. the most recently created of the wallet's own pending txs.
* `tx.isAbandoned()` pending txs are skipped, mirroring how `pwallet->mapWallet` consumers usually treat them.

## Schema notes

Pending entries have no canonical chain height, so the existing `height`, `expires_in`, and `expired` fields are omitted for them. The result schema now marks those three fields as optional. The output for confirmed entries (with or without `includePending`) is byte-for-byte unchanged.

The new `pending` and `op` fields are also optional and only appear on unconfirmed entries.

## Companion changes

This PR is the third leg of three closely-related changes:

* **#585** (already open) — adds `mineOnly` to `name_pending` and fixes the underlying `MaybeWalletForRequest`/typeid-duplication bug so `name_pending`, `name_show`, `name_history`, and `name_scan` actually populate `ismine` on platforms where `wallet::WalletContext` typeinfo gets duplicated across the static node and wallet libraries (notably macOS).
* This PR — adds `includePending` to `name_list`.
* **namecoin/electrum-nmc#405** — uses the same `pending` / `op` field names in electrum-nmc's `name_list` daemon command output. The field names here are picked to match so wallet UIs written against either backend can share parsing.

This branch is currently stacked on top of #585. The two name-list-side changes (the underlying ismine fix and `includePending`) are independent, but stacking lets reviewers see the full picture and lets me share the same test infrastructure between the two PRs. If reviewers prefer this PR rebased onto `master` independently, I'll do it.

## Tests

A new functional test, `test/functional/name_list_pending.py`, covers:

* the default `name_list` behavior is unchanged,
* `includePending` without any pending wallet tx matches the default,
* a pending `name_update` replaces the confirmed entry for that name and carries `pending=true`, `op="name_update"`,
* confirmed entries for other names are not touched,
* the name filter composes with `includePending`,
* once the pending tx confirms, the entry loses the pending / op fields and gains real expiration data again.

I ran the full `name_*.py` battery locally on macOS arm64 with all three commits applied — all 28 tests pass:

```
TEST                            | STATUS    | DURATION
name_allowexpired.py            | ✓ Passed  |  2 s
name_ant_workflow.py            | ✓ Passed  |  4 s
name_bumpfee.py                 | ✓ Passed  |  2 s
name_byhash.py                  | ✓ Passed  |  1 s
name_encodings.py               | ✓ Passed  | 15 s
name_expiration.py              | ✓ Passed  |  1 s
name_immature_inputs.py         | ✓ Passed  |  8 s
name_ismine.py                  | ✓ Passed  |  3 s
name_list.py                    | ✓ Passed  |  4 s
name_list_pending.py            | ✓ Passed  |  0 s
name_listunspent.py             | ✓ Passed  |  8 s
name_longsalt.py                | ✓ Passed  |  2 s
name_multisig.py                | ✓ Passed  | 16 s
name_multisig.py --bip16-active | ✓ Passed  | 14 s
name_multiupdate.py             | ✓ Passed  |  0 s
name_novalue.py                 | ✓ Passed  |  0 s
name_pending.py                 | ✓ Passed  |  4 s
name_pending_mineonly.py        | ✓ Passed  | 14 s
name_psbt.py                    | ✓ Passed  |  2 s
name_rawtx.py                   | ✓ Passed  |  7 s
name_registration.py            | ✓ Passed  | 18 s
name_reorg.py                   | ✓ Passed  |  1 s
name_scanning.py                | ✓ Passed  |  1 s
name_segwit.py                  | ✓ Passed  |  0 s
name_sendcoins.py               | ✓ Passed  |  0 s
name_txnqueue.py                | ✓ Passed  |  1 s
name_utxo.py                    | ✓ Passed  |  1 s
name_wallet.py                  | ✓ Passed  | 10 s
```

Build: macOS 15 arm64, clang from Xcode toolchain, CMake build with default flags, `ENABLE_WALLET=ON`.

## RFC notes / questions for review

This is shaped as something close to a draft; happy to iterate on:

* **Tie-break for multiple pending wallet txs on the same name.** I went with highest `nOrderPos` (most-recently-added to the wallet). An alternative is "first one found in the mempool that's not RBF-replaced." `nOrderPos` keeps the implementation entirely wallet-side without needing to consult the mempool again, and matches what a UI would intuitively want ("show me my latest intent"), but I can switch if reviewers prefer the mempool-anchored interpretation.
* **Pending replaces confirmed.** If reviewers prefer to emit *both* rows (one pending, one confirmed) for clarity, I can make that the default and gate the merge behind a separate flag like `mergePending`. That said, every wallet UI I've seen wants the merged view, and the schema cost of adding two rows for one name is non-trivial.
* **Mempool-only-not-yet-in-wallet.** This PR only includes pending name ops that are in `pwallet->mapWallet`. It does not include "someone else broadcast a tx that transfers a name to my wallet but the tx isn't in my wallet yet." Adding that would require touching the mempool from `name_list`, which I'd rather do as a separate change if at all.
